### PR TITLE
Enabe origins_workflow and layout modules; rename config to support

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -63,7 +63,6 @@ module:
   metatag_verification: 0
   migrate: 0
   migrate_plus: 0
-  nicsdru_layouts: 0
   nidirect_breadcrumbs: 0
   nidirect_cold_weather_payments: 0
   nidirect_common: 0
@@ -78,6 +77,8 @@ module:
   node: 0
   options: 0
   origins_common: 0
+  origins_layouts: 0
+  origins_workflow: 0
   page_cache: 0
   paragraphs_inline_entity_form: 0
   path: 0

--- a/config/sync/origins_workflow.auditsettings.yml
+++ b/config/sync/origins_workflow.auditsettings.yml
@@ -1,3 +1,7 @@
 audit_button_text: 'Audit this published content'
 audit_button_hover_text: 'Click this link to indicate you have checked this content for accuracy and relevance'
 audit_confirmation_text: 'Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.'
+audit_content_types:
+  article: article
+  news: 0
+  publication: 0


### PR DESCRIPTION
NB: assumes that https://github.com/dof-dss/nicsdru_origins_modules/pull/3 has either been merged into `development` or (as in my case) is checked out on a temporary evaluation branch.

I believe this will compliment https://github.com/dof-dss/nidirect-drupal/pull/28 which is involved with renaming nidirect_workflow to nicsdru_workflow.