### PR TITLE
Add config for search autocomplete and block

### DIFF
--- a/config/sync/block.block.sitesearchblock.yml
+++ b/config/sync/block.block.sitesearchblock.yml
@@ -1,4 +1,4 @@
-uuid: bcd31f12-3b6f-4852-be60-03e09b9a8818
+uuid: c86287b8-2f26-4e18-a9a9-fb026899ea98
 langcode: en
 status: true
 dependencies:
@@ -6,9 +6,9 @@ dependencies:
     - nidirect_common
     - system
   theme:
-    - bartik
+    - nicsdru_nidirect_theme
 id: sitesearchblock
-theme: bartik
+theme: nicsdru_nidirect_theme
 region: header
 weight: 0
 provider: null

--- a/config/sync/block.block.sitesearchblock.yml
+++ b/config/sync/block.block.sitesearchblock.yml
@@ -1,0 +1,26 @@
+uuid: bcd31f12-3b6f-4852-be60-03e09b9a8818
+langcode: en
+status: true
+dependencies:
+  module:
+    - nidirect_common
+    - system
+  theme:
+    - bartik
+id: sitesearchblock
+theme: bartik
+region: header
+weight: 0
+provider: null
+plugin: site_search_block
+settings:
+  id: site_search_block
+  label: 'Site search block'
+  provider: nidirect_common
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: '/search*'
+    negate: true
+    context_mapping: {  }

--- a/config/sync/search_api_autocomplete.search.search.yml
+++ b/config/sync/search_api_autocomplete.search.search.yml
@@ -21,6 +21,7 @@ suggester_settings:
         contact: ''
         driving_instructor: ''
         embargoed_publication: ''
+        gp_practice: ''
         landing_page: ''
         news: ''
         page: ''
@@ -35,10 +36,11 @@ search_settings:
   'views:search':
     displays:
       default: true
-      selected: {  }
+      selected:
+        - default
 options:
   limit: 5
-  min_length: 1
+  min_length: 2
   show_count: false
   autosubmit: true
   submit_button_selector: ':submit'

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -315,3 +315,170 @@ display:
         - url
         - url.query_args
       tags: {  }
+  site_search:
+    display_plugin: embed
+    id: site_search
+    display_title: 'Embed: Site search'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      fields:
+        title:
+          id: title
+          table: search_api_index_default_content
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+          plugin_id: search_api_field
+      defaults:
+        fields: false
+        pager: false
+        exposed_form: false
+        empty: false
+        filters: false
+        filter_groups: false
+      pager:
+        type: some
+        options:
+          items_per_page: 5
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Go
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: false
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      empty: {  }
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_default_content
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: ''
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            identifier: query
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              gp_author_user: '0'
+              author_user: '0'
+              gp_supervisor_user: '0'
+              news_supervisor: '0'
+              supervisor_user: '0'
+              editor_user: '0'
+              admin_user: '0'
+              apps_user: '0'
+              health_condition_author_user: '0'
+              health_condition_supervisor_user: '0'
+              driving_instructor_supervisor_user: '0'
+            placeholder: 'Search nidirect'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+          plugin_id: search_api_fulltext
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+      tags: {  }


### PR DESCRIPTION
There's a corresponding PR in the site-modules repo that provides a block for the views embed display to sit inside. Using views block display means you can't get the form to submit to a different page as the AJAX behaviour reloads the same page on submit.