### PR TITLE
D8NID-197 Config for health condition alternative node type

### DIFF
--- a/config/sync/core.base_field_override.node.health_condition_alternative.promote.yml
+++ b/config/sync/core.base_field_override.node.health_condition_alternative.promote.yml
@@ -1,0 +1,22 @@
+uuid: d23522fb-82c3-4caa-966e-cde03326056d
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.health_condition_alternative
+id: node.health_condition_alternative.promote
+field_name: promote
+entity_type: node
+bundle: health_condition_alternative
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.base_field_override.node.health_condition_alternative.status.yml
+++ b/config/sync/core.base_field_override.node.health_condition_alternative.status.yml
@@ -1,0 +1,22 @@
+uuid: 661d3b83-0b4f-4af8-a2df-36d74c298111
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.health_condition_alternative
+id: node.health_condition_alternative.status
+field_name: status
+entity_type: node
+bundle: health_condition_alternative
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.entity_form_display.node.health_condition.default.yml
+++ b/config/sync/core.entity_form_display.node.health_condition.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.health_condition.body
     - field.field.node.health_condition.field_additional_info
+    - field.field.node.health_condition.field_alternative_condition
     - field.field.node.health_condition.field_alternative_title
     - field.field.node.health_condition.field_banner_image
     - field.field.node.health_condition.field_enable_toc
@@ -35,11 +36,12 @@ dependencies:
     - node.type.health_condition
     - workflows.workflow.editorial
   module:
-    - chosen_field
     - content_moderation
     - datetime
+    - entity_browser_entity_form
     - field_group
     - image
+    - inline_entity_form
     - link
     - metatag
     - path
@@ -53,12 +55,13 @@ third_party_settings:
         - field_hc_body_system
         - field_hc_condition_type
         - field_hc_primary_symptom_1
+        - field_top_level_theme
         - field_hc_primary_symptom_2
         - field_hc_primary_symptom_3
         - field_hc_primary_symptom_4
         - field_hc_secondary_symptoms
       parent_name: ''
-      weight: 22
+      weight: 15
       format_type: details
       format_settings:
         id: group_hc_classification
@@ -66,6 +69,7 @@ third_party_settings:
         open: false
         required_fields: true
       label: 'Classification information'
+      region: content
 id: node.health_condition.default
 targetEntityType: node
 bundle: health_condition
@@ -73,7 +77,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 13
+    weight: 11
     settings:
       rows: 9
       summary_rows: 3
@@ -82,29 +86,39 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 24
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   field_additional_info:
     type: text_textarea
-    weight: 15
+    weight: 13
     region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-  field_alternative_title:
-    type: string_textfield
+  field_alternative_condition:
     weight: 1
-    region: content
     settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
+      form_mode: default
+      label_singular: ''
+      label_plural: ''
+      collapsible: true
+      allow_new: true
+      allow_existing: true
+      match_operator: STARTS_WITH
+      override_labels: false
+      collapsed: false
+      allow_duplicate: false
+    third_party_settings:
+      entity_browser_entity_form:
+        entity_browser_id: _none
+    type: inline_entity_form_complex
+    region: content
   field_banner_image:
     type: image_image
-    weight: 8
+    weight: 6
     region: content
     settings:
       progress_indicator: throbber
@@ -112,7 +126,7 @@ content:
     third_party_settings: {  }
   field_enable_toc:
     type: boolean_checkbox
-    weight: 14
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -146,7 +160,7 @@ content:
     third_party_settings: {  }
   field_hc_info_source:
     type: options_buttons
-    weight: 16
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -195,33 +209,27 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_index_letter:
-    type: chosen_select
-    weight: 3
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_last_review_date:
     type: datetime_default
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   field_meta_tags:
-    weight: 29
+    weight: 26
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
     region: content
   field_next_review_date:
     type: datetime_default
-    weight: 20
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   field_parent_condition:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 2
     region: content
     settings:
       match_operator: CONTAINS
@@ -230,7 +238,7 @@ content:
     third_party_settings: {  }
   field_photo:
     type: image_image
-    weight: 9
+    weight: 7
     region: content
     settings:
       progress_indicator: throbber
@@ -238,13 +246,13 @@ content:
     third_party_settings: {  }
   field_published_date:
     type: datetime_default
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   field_related_conditions:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
@@ -253,7 +261,7 @@ content:
     third_party_settings: {  }
   field_related_info:
     type: link_default
-    weight: 17
+    weight: 16
     region: content
     settings:
       placeholder_url: ''
@@ -261,7 +269,7 @@ content:
     third_party_settings: {  }
   field_site_themes:
     type: options_shs
-    weight: 7
+    weight: 5
     region: content
     settings:
       display_node_count: false
@@ -271,7 +279,7 @@ content:
     third_party_settings: {  }
   field_subtheme:
     type: options_shs
-    weight: 6
+    weight: 4
     region: content
     settings:
       display_node_count: false
@@ -280,7 +288,7 @@ content:
       force_deepest: false
     third_party_settings: {  }
   field_summary:
-    weight: 12
+    weight: 10
     settings:
       rows: 5
       placeholder: ''
@@ -289,33 +297,42 @@ content:
     region: content
   field_teaser:
     type: string_textfield
-    weight: 10
+    weight: 8
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_top_level_theme:
+    type: entity_reference_autocomplete
+    weight: 23
+    region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   flag:
-    weight: 11
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 29
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 30
+    weight: 27
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 27
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -323,21 +340,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 25
+    weight: 22
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 28
+    weight: 25
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 26
+    weight: 23
     region: content
     third_party_settings: {  }
   title:
@@ -350,7 +367,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 23
+    weight: 20
     settings:
       match_operator: CONTAINS
       size: 60
@@ -358,9 +375,10 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 34
+    weight: 28
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_top_level_theme: true
+  field_alternative_title: true
+  field_index_letter: true

--- a/config/sync/core.entity_form_display.node.health_condition_alternative.default.yml
+++ b/config/sync/core.entity_form_display.node.health_condition_alternative.default.yml
@@ -1,0 +1,45 @@
+uuid: ec90de89-d748-4b4a-8255-bf419868b4b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.health_condition_alternative.field_parent_condition
+    - node.type.health_condition_alternative
+id: node.health_condition_alternative.default
+targetEntityType: node
+bundle: health_condition_alternative
+mode: default
+content:
+  field_parent_condition:
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  moderation_state: true
+  path: true
+  promote: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/sync/core.entity_view_display.node.health_condition.default.yml
+++ b/config/sync/core.entity_view_display.node.health_condition.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.health_condition.body
     - field.field.node.health_condition.field_additional_info
+    - field.field.node.health_condition.field_alternative_condition
     - field.field.node.health_condition.field_alternative_title
     - field.field.node.health_condition.field_banner_image
     - field.field.node.health_condition.field_enable_toc
@@ -59,6 +60,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_alternative_condition:
+    weight: 11
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_alternative_title:
     type: string
     weight: 4

--- a/config/sync/core.entity_view_display.node.health_condition_alternative.default.yml
+++ b/config/sync/core.entity_view_display.node.health_condition_alternative.default.yml
@@ -1,0 +1,30 @@
+uuid: 2f5f3c77-8e35-430b-95f7-2d36dc3a20ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.health_condition_alternative.field_parent_condition
+    - node.type.health_condition_alternative
+  module:
+    - user
+id: node.health_condition_alternative.default
+targetEntityType: node
+bundle: health_condition_alternative
+mode: default
+content:
+  field_parent_condition:
+    weight: 101
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  links:
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.health_condition_alternative.search_result.yml
+++ b/config/sync/core.entity_view_display.node.health_condition_alternative.search_result.yml
@@ -1,0 +1,33 @@
+uuid: 11cefa86-2c19-49d6-9dd7-9c910cfb2dfd
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_result
+    - field.field.node.health_condition_alternative.field_parent_condition
+    - node.type.health_condition_alternative
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: node.health_condition_alternative.search_result
+targetEntityType: node
+bundle: health_condition_alternative
+mode: search_result
+content:
+  field_parent_condition:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_result
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  langcode: true
+  links: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.health_condition_alternative.teaser.yml
+++ b/config/sync/core.entity_view_display.node.health_condition_alternative.teaser.yml
@@ -1,0 +1,24 @@
+uuid: bc057266-be8d-495e-bef0-e2de23b15712
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.health_condition_alternative.field_parent_condition
+    - node.type.health_condition_alternative
+  module:
+    - user
+id: node.health_condition_alternative.teaser
+targetEntityType: node
+bundle: health_condition_alternative
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_parent_condition: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.node.health_condition.field_alternative_condition.yml
+++ b/config/sync/field.field.node.health_condition.field_alternative_condition.yml
@@ -1,0 +1,28 @@
+uuid: 4a904fb8-8ee9-4e0c-bb97-296e38a1a916
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_alternative_condition
+    - node.type.health_condition
+    - node.type.health_condition_alternative
+id: node.health_condition.field_alternative_condition
+field_name: field_alternative_condition
+entity_type: node
+bundle: health_condition
+label: 'Alternative condition titles'
+description: "<p>Alternative titles for this condition. These reference a health condition and appear in the A-Z directory with the alternative title value followed by the content of the health condition.</p>\r\n<p>For example, 'coughing' can also appear as 'whooping cough' by using this field.</p>"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      health_condition_alternative: health_condition_alternative
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.health_condition_alternative.field_parent_condition.yml
+++ b/config/sync/field.field.node.health_condition_alternative.field_parent_condition.yml
@@ -1,0 +1,28 @@
+uuid: dd9bebed-fd22-42bd-ab3e-69fb7f835e6f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_parent_condition
+    - node.type.health_condition
+    - node.type.health_condition_alternative
+id: node.health_condition_alternative.field_parent_condition
+field_name: field_parent_condition
+entity_type: node
+bundle: health_condition_alternative
+label: 'Parent condition'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      health_condition: health_condition
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_alternative_condition.yml
+++ b/config/sync/field.storage.node.field_alternative_condition.yml
@@ -1,0 +1,19 @@
+uuid: ccb90936-7b41-409c-ad95-c736f7a0e0ab
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_alternative_condition
+field_name: field_alternative_condition
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.node.health_condition_alternative.yml
+++ b/config/sync/language.content_settings.node.health_condition_alternative.yml
@@ -1,0 +1,11 @@
+uuid: 3cfedaec-c912-40fb-94f0-ba1fac01a3ed
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.health_condition_alternative
+id: node.health_condition_alternative
+target_entity_type_id: node
+target_bundle: health_condition_alternative
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/node.type.health_condition_alternative.yml
+++ b/config/sync/node.type.health_condition_alternative.yml
@@ -1,0 +1,17 @@
+uuid: ca08ab11-6aab-4e6e-94c8-7d57e76c10ca
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: 'Health condition: alternative'
+type: health_condition_alternative
+description: 'Some health conditions are known by alternative names. This content type is intended to act as a container for that alternative information'
+help: ''
+new_revision: true
+preview_mode: 0
+display_submitted: false

--- a/config/sync/views.view.health_conditions_a_to_z.yml
+++ b/config/sync/views.view.health_conditions_a_to_z.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - node.type.health_condition
+    - node.type.health_condition_alternative
   module:
     - node
     - user
@@ -246,6 +247,93 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
+      filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            health_condition: health_condition
+            health_condition_alternative: health_condition_alternative
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Content type, fields, display modes and views tweak.

This PR removes the extensive views preprocessing and instead uses a shallow node type to track/define the relationships between them and the original health condition.