### PR TITLE
Remove search_api_solr_devel from local split

### DIFF
--- a/config/sync/config_split.config_split.local.yml
+++ b/config/sync/config_split.config_split.local.yml
@@ -13,7 +13,6 @@ module:
   kint: 0
   memcache_admin: 0
   search_api_solr_admin: 0
-  search_api_solr_devel: 0
   stage_file_proxy: 0
   syslog: 0
   update: 0


### PR DESCRIPTION
Because it generally obstructs the view of anything you want to look at
in the admin theme. Should default to being something you can switch on
as/when needed.