### PR TITLE
Block config for footer menu and origins theme settings values

### DIFF
--- a/config/sync/block.block.footer.yml
+++ b/config/sync/block.block.footer.yml
@@ -1,0 +1,30 @@
+uuid: 2b367cf7-b333-427d-9bee-920df8e911f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.footer
+  module:
+    - system
+  theme:
+    - nicsdru_nidirect_theme
+id: footer
+theme: nicsdru_nidirect_theme
+region: footer
+weight: 0
+provider: null
+plugin: 'system_menu_block:footer'
+settings:
+  id: 'system_menu_block:footer'
+  label: Footer
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility:
+  request_path:
+    id: request_path
+    pages: '*'
+    negate: false
+    context_mapping: {  }

--- a/config/sync/nicsdru_origins_theme.settings.yml
+++ b/config/sync/nicsdru_origins_theme.settings.yml
@@ -1,0 +1,13 @@
+features:
+  node_user_picture: 1
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: 1
+logo:
+  use_default: 1
+favicon:
+  use_default: 1
+social_links_twitter: 'https://twitter.com/nidirect'
+social_links_facebook: 'https://www.facebook.com/nidirect'
+social_links_youtube: 'https://www.youtube.com/user/nidirect'
+social_links_rss: /news-rss.xml


### PR DESCRIPTION
NB: To avoid any confusion on first import... the footer menu will likely be empty on initial config import as menu links are considered content and aren't carried with the config export. Once the values are filled in by an admin, or we've faked them in code (if needed) things ought to look clearer :)