### PR TITLE
D8NID-384 Set safe handling of basic html + full html text formats

### DIFF
--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -17,85 +17,85 @@ filters:
   filter_html:
     id: filter_html
     provider: filter
-    status: false
+    status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption> <drupal-entity alt title data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button> <sup> <a href hreflang !href accesskey id rel target title> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr>'
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <img src alt height width data-* typeof> <sup> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <drupal-entity data-* data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button alt title class> <picture data-* alt title class> <source srcset media type>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:
     id: filter_align
     provider: filter
     status: false
-    weight: -43
+    weight: -42
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: false
-    weight: -42
+    weight: -41
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: false
-    weight: -40
+    weight: -39
     settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: true
-    weight: -45
+    weight: -48
     settings: {  }
   filter_autop:
     id: filter_autop
     provider: filter
     status: false
-    weight: -47
+    weight: -44
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: false
-    weight: -48
+    weight: -45
     settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -44
+    weight: -43
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: false
-    weight: -49
+    weight: -46
     settings:
       filter_url_length: 72
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -41
+    weight: -40
     settings: {  }
   noreferrer:
     id: noreferrer
     provider: noreferrer
-    status: false
-    weight: -46
+    status: true
+    weight: -49
     settings: {  }
   token_filter:
     id: token_filter
     provider: token_filter
     status: false
-    weight: -39
+    weight: -38
     settings:
       replace_empty: '0'
   filter_media_responsive_image_style:
     id: filter_media_responsive_image_style
     provider: media_browser_responsive_images
     status: true
-    weight: 0
+    weight: -47
     settings:
       responsive_style_inline: '1'
       responsive_style_inline_xl_tbc: '1'

--- a/config/sync/filter.format.full_html.yml
+++ b/config/sync/filter.format.full_html.yml
@@ -18,43 +18,43 @@ filters:
     id: filter_align
     provider: filter
     status: false
-    weight: -45
+    weight: -43
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: false
-    weight: -44
+    weight: -42
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
-    status: true
+    status: false
     weight: -49
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: false
-    weight: -43
+    weight: -41
     settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: true
-    weight: -46
+    weight: -45
     settings: {  }
   filter_autop:
     id: filter_autop
     provider: filter
-    status: true
+    status: false
     weight: -48
     settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -41
+    weight: -39
     settings: {  }
   filter_url:
     id: filter_url
@@ -67,13 +67,13 @@ filters:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -40
+    weight: -38
     settings: {  }
   filter_html:
     id: filter_html
     provider: filter
     status: false
-    weight: -42
+    weight: -40
     settings:
       allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <p> <h1> <pre> <drupal-entity data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button> <sup> <a href hreflang !href accesskey id rel target title> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr>'
       filter_html_help: true
@@ -88,14 +88,14 @@ filters:
     id: token_filter
     provider: token_filter
     status: true
-    weight: -39
+    weight: -46
     settings:
-      replace_empty: '0'
+      replace_empty: '1'
   filter_media_responsive_image_style:
     id: filter_media_responsive_image_style
     provider: media_browser_responsive_images
     status: true
-    weight: 0
+    weight: -44
     settings:
       responsive_style_inline: '1'
       responsive_style_inline_xl_tbc: '1'


### PR DESCRIPTION
- Whitelist from CS site's settings; respects entity embed and responsive images.
- Sets whitelist first; never trust user input to be safe.
- Remove tidying/hand-holding filters for full html; users will know what they're doing if they have perms to use this.