### PR TITLE
Revoke blanket view terms permission for all but editor/admin roles

### DIFF
--- a/config/sync/user.role.admin_user.yml
+++ b/config/sync/user.role.admin_user.yml
@@ -302,7 +302,6 @@ permissions:
   - 'view page revisions'
   - 'view publication revisions'
   - 'view recipe revisions'
-  - 'view terms in site_themes'
   - 'view the administration theme'
   - 'view umbrella_body revisions'
   - 'view webform revisions'

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -15,4 +15,3 @@ permissions:
   - 'use search_api_autocomplete for search'
   - use_search_api_live_results
   - 'view files'
-  - 'view terms in site_themes'

--- a/config/sync/user.role.apps_user.yml
+++ b/config/sync/user.role.apps_user.yml
@@ -12,4 +12,3 @@ permissions:
   - 'edit weather stations'
   - 'use editorial transition create_new_draft'
   - 'use text format basic_html'
-  - 'view terms in site_themes'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -31,5 +31,4 @@ permissions:
   - 'view moderation messages'
   - 'view own unpublished content'
   - 'view revisions'
-  - 'view terms in site_themes'
   - 'view the administration theme'

--- a/config/sync/user.role.author_user.yml
+++ b/config/sync/user.role.author_user.yml
@@ -110,5 +110,4 @@ permissions:
   - 'view news revisions'
   - 'view own files'
   - 'view publication revisions'
-  - 'view terms in site_themes'
   - 'view the administration theme'

--- a/config/sync/user.role.driving_instructor_supervisor_user.yml
+++ b/config/sync/user.role.driving_instructor_supervisor_user.yml
@@ -38,4 +38,3 @@ permissions:
   - 'use workbench_moderation my drafts tab'
   - 'use workbench_moderation needs review tab'
   - 'view driving_instructor revisions'
-  - 'view terms in site_themes'

--- a/config/sync/user.role.gp_author_user.yml
+++ b/config/sync/user.role.gp_author_user.yml
@@ -49,5 +49,4 @@ permissions:
   - 'view gp_practice revisions'
   - 'view own files'
   - 'view published gp entities'
-  - 'view terms in site_themes'
   - 'view unpublished gp entities'

--- a/config/sync/user.role.gp_supervisor_user.yml
+++ b/config/sync/user.role.gp_supervisor_user.yml
@@ -58,4 +58,3 @@ permissions:
   - 'use workbench_moderation needs review tab'
   - 'view gp_practice revisions'
   - 'view own files'
-  - 'view terms in site_themes'

--- a/config/sync/user.role.health_condition_author_user.yml
+++ b/config/sync/user.role.health_condition_author_user.yml
@@ -31,4 +31,3 @@ permissions:
   - 'use workbench_moderation needs review tab'
   - 'view health_condition revisions'
   - 'view health_condition_alternative revisions'
-  - 'view terms in site_themes'

--- a/config/sync/user.role.health_condition_supervisor_user.yml
+++ b/config/sync/user.role.health_condition_supervisor_user.yml
@@ -56,4 +56,3 @@ permissions:
   - 'use workbench_moderation needs review tab'
   - 'view health_condition revisions'
   - 'view health_condition_alternative revisions'
-  - 'view terms in site_themes'

--- a/config/sync/user.role.news_supervisor.yml
+++ b/config/sync/user.role.news_supervisor.yml
@@ -19,4 +19,3 @@ permissions:
   - 'use editorial transition create_new_draft'
   - 'use text format basic_html'
   - 'view news revisions'
-  - 'view terms in site_themes'

--- a/config/sync/user.role.supervisor_user.yml
+++ b/config/sync/user.role.supervisor_user.yml
@@ -174,5 +174,4 @@ permissions:
   - 'view moderation messages'
   - 'view own files'
   - 'view publication revisions'
-  - 'view terms in site_themes'
   - 'view the administration theme'


### PR DESCRIPTION
https://www.drupal.org/sa-contrib-2019-093 introduced a new permission, this commit keeps our config in step with its impact