### PR TITLE
use custom cache tags

### DIFF
--- a/config/sync/views.view.related_content.yml
+++ b/config/sync/views.view.related_content.yml
@@ -15,6 +15,7 @@ dependencies:
     - node
     - text
     - user
+    - views_custom_cache_tag
 id: related_content
 label: 'Related content'
 module: views
@@ -34,8 +35,9 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: custom_tag
+        options:
+          custom_tag: 'taxonomy_term_list:{{ arguments.field_subtheme_target_id }}'
       query:
         type: views_query
         options:


### PR DESCRIPTION
Replace the dreaded the 'node_list' cache tag that was being produced by both block displays in the 'Related Content' view - replaced with the more specific custom cache tag 'taxonomy_term_list:<tid>'