### PR TITLE
Reinstate fulltext search on contacts search API view

### DIFF
--- a/config/sync/views.view.contacts.yml
+++ b/config/sync/views.view.contacts.yml
@@ -159,6 +159,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -166,8 +168,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -182,26 +182,25 @@ display:
             group_items: {  }
           reduce_duplicates: false
           plugin_id: search_api_options
-        title:
-          id: title
+        search_api_fulltext:
+          id: search_api_fulltext
           table: search_api_index_default_content
-          field: title
+          field: search_api_fulltext
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
+          operator: and
+          value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: title_op
+            operator_id: search_api_fulltext_op
             label: 'Search by contact name'
             description: ''
             use_operator: false
-            operator: title_op
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: query_contacts_az
             required: false
             remember: false
@@ -222,10 +221,6 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: 'Search contacts'
-            min_placeholder: ''
-            max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -238,7 +233,10 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: search_api_text
+          parse_mode: phrase
+          min_length: 3
+          fields: {  }
+          plugin_id: search_api_fulltext
       sorts:
         search_api_relevance:
           id: search_api_relevance


### PR DESCRIPTION
Prior to this, the view wasn't correctly interrogating Solr for content resulting in zero results