### PR TITLE
Search api solarium library upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,6 +124,7 @@
         "drupal/whatlinkshere": "^1.0",
         "drush/drush": "^9.0.0",
         "harvesthq/chosen": "^1.8",
+        "symfony/event-dispatcher": "4.3.4 as 3.4.35",
         "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aae4bdea98f044dadc1b765d63a46efb",
+    "content-hash": "792a2d1bda96a03a1d88285b4f35d482",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2032,7 +2032,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0",
-                    "datestamp": "1573751237",
+                    "datestamp": "1572370984",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3701,7 +3701,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1562161679",
+                    "datestamp": "1561765981",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3732,10 +3732,6 @@
                 {
                     "name": "cs_shadow",
                     "homepage": "https://www.drupal.org/user/2828287"
-                },
-                {
-                    "name": "oknate",
-                    "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
                     "name": "phenaproxima",
@@ -5425,21 +5421,21 @@
         },
         {
             "name": "drupal/search_api_solr",
-            "version": "3.7.0",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/search_api_solr.git",
-                "reference": "8.x-3.7"
+                "reference": "8.x-3.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/search_api_solr-8.x-3.7.zip",
-                "reference": "8.x-3.7",
-                "shasum": "573e18996ab6448a92d32aebcf3d760f5cea2fca"
+                "url": "https://ftp.drupal.org/files/projects/search_api_solr-8.x-3.8.zip",
+                "reference": "8.x-3.8",
+                "shasum": "5c47090d817410ae06a6e096f2aabf3f99e43520"
             },
             "require": {
                 "consolidation/annotated-command": "^2.12",
-                "drupal/core": "^8.6",
+                "drupal/core": "^8.7",
                 "drupal/search_api": "~1.14",
                 "ext-dom": "*",
                 "ext-json": "*",
@@ -5450,7 +5446,7 @@
                 "zendframework/zend-stdlib": "^3.0.1"
             },
             "conflict": {
-                "drupal/core": "<8.6",
+                "drupal/core": "<8.7",
                 "drupal/search_api_solr_multilingual": "<3.0.0"
             },
             "require-dev": {
@@ -5475,8 +5471,8 @@
                     "dev-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.7",
-                    "datestamp": "1570049584",
+                    "version": "8.x-3.8",
+                    "datestamp": "1577980383",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5565,10 +5561,6 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
-                {
-                    "name": "jhedstrom",
-                    "homepage": "https://www.drupal.org/user/208732"
-                },
                 {
                     "name": "stBorchert",
                     "homepage": "https://www.drupal.org/user/36942"
@@ -7947,52 +7939,6 @@
             "time": "2015-02-10T20:07:52+00:00"
         },
         {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -8254,23 +8200,22 @@
         },
         {
             "name": "solarium/solarium",
-            "version": "5.0.3",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/solariumphp/solarium.git",
-                "reference": "fcec6d7fa9d6704e45afed0d050ff069f3e0e86f"
+                "reference": "3abd884313a52c47cefb44a6daa27f1d6eb253f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/solariumphp/solarium/zipball/fcec6d7fa9d6704e45afed0d050ff069f3e0e86f",
-                "reference": "fcec6d7fa9d6704e45afed0d050ff069f3e0e86f",
+                "url": "https://api.github.com/repos/solariumphp/solarium/zipball/3abd884313a52c47cefb44a6daa27f1d6eb253f6",
+                "reference": "3abd884313a52c47cefb44a6daa27f1d6eb253f6",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^7.1",
-                "symfony/cache": "^3.1 || ^4.0",
-                "symfony/event-dispatcher": "^3.1 || ^4.0"
+                "php": "^7.1.3",
+                "symfony/event-dispatcher": "^4.3 || ^5.0"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^3.8 || ^6.2",
@@ -8283,11 +8228,6 @@
                 "minimalcode/search": "Query builder compatible with Solarium, allows simplified solr-query handling"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Solarium\\": "src/"
@@ -8310,7 +8250,7 @@
                 "search",
                 "solr"
             ],
-            "time": "2019-07-05T14:34:48+00:00"
+            "time": "2019-12-06T23:24:54+00:00"
         },
         {
             "name": "stack/builder",
@@ -8464,142 +8404,6 @@
                 "routing"
             ],
             "time": "2017-05-09T08:10:41+00:00"
-        },
-        {
-            "name": "symfony/cache",
-            "version": "v4.3.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache.git",
-                "reference": "2a7bcc592adcaab9efc165bbced5a91fe905fad4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/2a7bcc592adcaab9efc165bbced5a91fe905fad4",
-                "reference": "2a7bcc592adcaab9efc165bbced5a91fe905fad4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "psr/cache": "~1.0",
-                "psr/log": "~1.0",
-                "symfony/cache-contracts": "^1.1",
-                "symfony/service-contracts": "^1.1",
-                "symfony/var-exporter": "^4.2"
-            },
-            "conflict": {
-                "doctrine/dbal": "<2.5",
-                "symfony/dependency-injection": "<3.4",
-                "symfony/var-dumper": "<3.4"
-            },
-            "provide": {
-                "psr/cache-implementation": "1.0",
-                "psr/simple-cache-implementation": "1.0",
-                "symfony/cache-implementation": "1.0"
-            },
-            "require-dev": {
-                "cache/integration-tests": "dev-master",
-                "doctrine/cache": "~1.6",
-                "doctrine/dbal": "~2.5",
-                "predis/predis": "~1.1",
-                "psr/simple-cache": "^1.0",
-                "symfony/config": "~4.2",
-                "symfony/dependency-injection": "~3.4|~4.1",
-                "symfony/var-dumper": "^4.1.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Cache\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "caching",
-                "psr6"
-            ],
-            "time": "2019-12-01T10:50:31+00:00"
-        },
-        {
-            "name": "symfony/cache-contracts",
-            "version": "v1.1.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "af50d14ada9e4e82cfabfabdc502d144f89be0a1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/af50d14ada9e4e82cfabfabdc502d144f89be0a1",
-                "reference": "af50d14ada9e4e82cfabfabdc502d144f89be0a1",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "psr/cache": "^1.0"
-            },
-            "suggest": {
-                "symfony/cache-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Cache\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to caching",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-10-04T21:43:27+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -9032,30 +8836,37 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.35",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f9031c22ec127d4a2450760f81a8677fe8a10177"
+                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f9031c22ec127d4a2450760f81a8677fe8a10177",
-                "reference": "f9031c22ec127d4a2450760f81a8677fe8a10177",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
+                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "^3.4|^4.0",
+                "symfony/service-contracts": "^1.1",
+                "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -9064,7 +8875,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -9091,7 +8902,65 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-24T15:33:53+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-09-17T09:54:03+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -10002,64 +9871,6 @@
             "time": "2019-11-12T17:51:12+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v1.1.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
-                "reference": "ffc7f5692092df31515df2a5ecf3b7302b3ddacf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "psr/container": "^1.0"
-            },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-10-14T12:27:06+00:00"
-        },
-        {
             "name": "symfony/translation",
             "version": "v3.4.35",
             "source": {
@@ -10290,66 +10101,6 @@
                 "dump"
             ],
             "time": "2019-12-18T13:41:29+00:00"
-        },
-        {
-            "name": "symfony/var-exporter",
-            "version": "v4.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "e566070effe60b8d16b99e958cdbd92aa2e470cb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/e566070effe60b8d16b99e958cdbd92aa2e470cb",
-                "reference": "e566070effe60b8d16b99e958cdbd92aa2e470cb",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "require-dev": {
-                "symfony/var-dumper": "^4.1.1|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\VarExporter\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "clone",
-                "construct",
-                "export",
-                "hydrate",
-                "instantiate",
-                "serialize"
-            ],
-            "time": "2019-12-01T08:39:58+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -11752,10 +11503,6 @@
                 {
                     "name": "See contributors",
                     "homepage": "https://www.drupal.org/node/3236/committers"
-                },
-                {
-                    "name": "pcambra",
-                    "homepage": "https://www.drupal.org/user/122101"
                 },
                 {
                     "name": "salvis",
@@ -15212,7 +14959,14 @@
             "time": "2019-06-13T22:48:21+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "3.4.35",
+            "alias_normalized": "3.4.35.0",
+            "version": "4.3.4.0",
+            "package": "symfony/event-dispatcher"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
         "dof-dss/nicsdru_nidirect_theme": 20,

--- a/config/sync/search_api.index.default_content.yml
+++ b/config/sync/search_api.index.default_content.yml
@@ -4,44 +4,43 @@ status: true
 dependencies:
   module:
     - search_api_solr
-    - taxonomy
     - node
+    - taxonomy
     - search_api
   config:
     - field.storage.node.field_address
-    - field.storage.node.field_di_adi_no
-    - field.storage.node.field_di_areas
     - field.storage.node.body
+    - field.storage.node.field_di_areas
+    - field.storage.node.field_di_categories
+    - field.storage.node.field_contact_category
+    - field.storage.node.field_di_adi_no
+    - field.storage.node.field_di_firstname
+    - field.storage.node.field_di_lastname
+    - field.storage.node.field_email_address
     - field.storage.node.field_hc_body_location
     - field.storage.taxonomy_term.field_term_hc_synonyms
     - field.storage.node.field_hc_body_system
-    - field.storage.node.field_di_categories
-    - field.storage.node.field_contact_category
     - field.storage.node.field_hc_condition_type
-    - field.storage.node.field_ub_contact
-    - field.storage.node.field_recipe_allergens
-    - field.storage.node.field_ub_counties
-    - field.storage.node.field_recipe_course_type
-    - field.storage.node.field_email_address
-    - field.storage.node.field_di_firstname
-    - field.storage.node.field_index_letter
-    - field.storage.node.field_di_lastname
-    - field.storage.node.field_lb_search_content
-    - field.storage.node.field_recipe_main_ingredient
     - field.storage.node.field_hc_primary_symptom_1
     - field.storage.node.field_hc_primary_symptom_2
     - field.storage.node.field_hc_primary_symptom_3
     - field.storage.node.field_hc_primary_symptom_4
-    - field.storage.node.field_published_date
-    - field.storage.node.field_recipe_season
     - field.storage.node.field_hc_secondary_symptoms
-    - field.storage.node.field_ub_sector
-    - field.storage.node.field_ub_services
+    - field.storage.node.field_index_letter
+    - field.storage.node.field_published_date
+    - field.storage.node.field_recipe_allergens
+    - field.storage.node.field_recipe_course_type
     - field.storage.node.field_recipe_description
+    - field.storage.node.field_recipe_main_ingredient
+    - field.storage.node.field_recipe_season
     - field.storage.node.field_recipe_special_diet
-    - field.storage.node.field_summary
     - field.storage.node.field_site_themes
     - field.storage.node.field_subtheme
+    - field.storage.node.field_summary
+    - field.storage.node.field_ub_contact
+    - field.storage.node.field_ub_counties
+    - field.storage.node.field_ub_sector
+    - field.storage.node.field_ub_services
     - search_api.server.solr_default
 third_party_settings:
   search_api_solr:
@@ -345,14 +344,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_index_letter
-  field_lb_search_content:
-    label: 'LB Search content'
-    datasource_id: 'entity:node'
-    property_path: field_lb_search_content
-    type: text
-    dependencies:
-      config:
-        - field.storage.node.field_lb_search_content
   field_published_date:
     label: 'Published date'
     datasource_id: 'entity:node'

--- a/config/sync/search_api.server.solr_default.yml
+++ b/config/sync/search_api.server.solr_default.yml
@@ -43,3 +43,4 @@ backend_config:
   optimize: false
   site_hash: false
   rows: 10
+  environment: default

--- a/config/sync/search_api_autocomplete.search.contacts.yml
+++ b/config/sync/search_api_autocomplete.search.contacts.yml
@@ -1,6 +1,6 @@
 uuid: e9a68046-b084-4ffe-8570-4f9a9c1a606c
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - search_api.index.default_content

--- a/config/sync/search_api_solr.solr_cache.cache_document_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_cache.cache_document_default_7_0_0.yml
@@ -1,0 +1,17 @@
+uuid: 64e4501e-1606-4e6f-900b-294a5bdae686
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: ClPoYNWUET68N1rNueZg_5KeyC2sNona4FTbDF-j1ZE
+id: cache_document_default_7_0_0
+label: 'Document Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: document
+  class: solr.LRUCache
+  size: 512
+  initialSize: 512
+  autowarmCount: 0
+solr_configs: null

--- a/config/sync/search_api_solr.solr_cache.cache_fieldvalue_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_cache.cache_fieldvalue_default_7_0_0.yml
@@ -1,0 +1,21 @@
+uuid: 288c9d06-6056-4bdb-8c0d-a508f43fa15e
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 3rL3u7QmgEuqpnwDP4cb2-7nIv7xwf7V_WXZyrcHoGc
+id: cache_fieldvalue_default_7_0_0
+label: 'Field Value Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: fieldValue
+  class: solr.FastLRUCache
+  size: 512
+  autowarmCount: 128
+  showItems: 32
+solr_configs:
+  query:
+    -
+      name: enableLazyFieldLoading
+      VALUE: 'true'

--- a/config/sync/search_api_solr.solr_cache.cache_filter_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_cache.cache_filter_default_7_0_0.yml
@@ -1,0 +1,21 @@
+uuid: 0773fa99-f83e-49a7-be74-e2c7ee44c088
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: vq3VkGaE2DLoxkODTNhlaM8f4mgCN22b_XvadwGJXG8
+id: cache_filter_default_7_0_0
+label: 'Filter Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: filter
+  class: solr.FastLRUCache
+  size: 512
+  initialSize: 512
+  autowarmCount: 0
+solr_configs:
+  query:
+    -
+      name: useFilterForSortedQuery
+      VALUE: 'false'

--- a/config/sync/search_api_solr.solr_cache.cache_persegfilter_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_cache.cache_persegfilter_default_7_0_0.yml
@@ -1,0 +1,18 @@
+uuid: f9cca434-08ba-4793-9f66-45e23fc0ef3c
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: i1jxS-2SHFS6WaOhchNRw2Egt5YVnhLpVfq5h8dzPYE
+id: cache_persegfilter_default_7_0_0
+label: 'Per Segment Filter Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: perSegFilter
+  class: solr.search.LRUCache
+  size: 10
+  initialSize: 0
+  autowarmCount: 10
+  regenerator: solr.NoOpRegenerator
+solr_configs: null

--- a/config/sync/search_api_solr.solr_cache.cache_queryresult_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_cache.cache_queryresult_default_7_0_0.yml
@@ -1,0 +1,27 @@
+uuid: 23dfc03f-d6ef-4492-8079-208030f11a9b
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: SbahJ2YkJ9OYJZefxh8CfUXBfbfOMovWHaYa9Car6UQ
+id: cache_queryresult_default_7_0_0
+label: 'Query Result Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: queryResult
+  class: solr.LRUCache
+  size: 512
+  initialSize: 512
+  autowarmCount: 0
+solr_configs:
+  query:
+    -
+      name: queryResultWindowSize
+      VALUE: '20'
+    -
+      name: queryResultMaxDocsCached
+      VALUE: '200'
+    -
+      name: maxBooleanClauses
+      VALUE: '1024'

--- a/config/sync/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcaching_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcaching_default_7_0_0.yml
@@ -1,0 +1,18 @@
+uuid: c5a8ac2a-6a64-40ba-b48d-32abd1b28495
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: bxAjXM_xls--jwh5HZqTat__y2_4nQJCFFLD69Wvr8A
+id: request_dispatcher_httpcaching_default_7_0_0
+label: 'HTTP Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_dispatcher:
+  name: httpCaching
+  lastModFrom: openTime
+  etagSeed: Solr
+  cacheControl:
+    -
+      VALUE: 'max-age=30, public'

--- a/config/sync/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcachingnever_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcachingnever_default_7_0_0.yml
@@ -1,0 +1,14 @@
+uuid: 5feecfec-2b6a-433d-ae1d-0cb6ac1e4acf
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: UbxzckuoN-7-PLfjTgOkYEvrOC-6_1eVgrHSQvdvD74
+id: request_dispatcher_httpcachingnever_default_7_0_0
+label: 'HTTP Cache Never'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_dispatcher:
+  name: httpCaching
+  never304: true

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_autocomplete_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_autocomplete_default_7_0_0.yml
@@ -1,0 +1,54 @@
+uuid: 8fd15945-a493-4872-bcc2-9907f3f6d468
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: pYuahO9bLm6CkxAFR4fieJZxTfosiKyxUCMLG2rApeE
+id: request_handler_autocomplete_default_7_0_0
+label: Autocomplete
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /autocomplete
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: terms
+          VALUE: 'false'
+        -
+          name: distrib
+          VALUE: 'false'
+        -
+          name: spellcheck
+          VALUE: 'false'
+        -
+          name: spellcheck.onlyMorePopular
+          VALUE: 'true'
+        -
+          name: spellcheck.extendedResults
+          VALUE: 'false'
+        -
+          name: spellcheck.count
+          VALUE: '1'
+        -
+          name: suggest
+          VALUE: 'false'
+        -
+          name: suggest.count
+          VALUE: '10'
+  arr:
+    -
+      name: components
+      str:
+        -
+          VALUE: terms
+        -
+          VALUE: spellcheck
+        -
+          VALUE: suggest
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_elevate_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_elevate_default_7_0_0.yml
@@ -1,0 +1,43 @@
+uuid: f9f50a5b-d570-4f33-93c2-90185d92328c
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: awRUNLvDsGIt-mG3F50XkazfyvWMPDLB-_cGe8c17pU
+id: request_handler_elevate_default_7_0_0
+label: Elevator
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_handler:
+  name: /elevate
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: echoParams
+          VALUE: explicit
+        -
+          name: df
+          VALUE: id
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: elevator
+solr_configs:
+  searchComponents:
+    -
+      name: elevator
+      class: solr.QueryElevationComponent
+      str:
+        -
+          name: queryFieldType
+          VALUE: string
+        -
+          name: config-file
+          VALUE: elevate.xml

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_extract_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_extract_default_7_0_0.yml
@@ -1,0 +1,35 @@
+uuid: 99d888f0-25d7-455a-81d3-10977566b4cd
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 7vbCK-cOkMCZBmHr8iFW8A4oQx-k0svYhp52KHP9yEU
+id: request_handler_extract_default_7_0_0
+label: Extract
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /update/extract
+  class: solr.extraction.ExtractingRequestHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: lowernames
+          VALUE: 'true'
+        -
+          name: uprefix
+          VALUE: ignored_
+        -
+          name: captureAttr
+          VALUE: 'true'
+        -
+          name: fmap.a
+          VALUE: links
+        -
+          name: fmap.div
+          VALUE: ignored_
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_mlt_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_mlt_default_7_0_0.yml
@@ -1,0 +1,31 @@
+uuid: de8d73a0-08f8-4f47-9d2f-c02be789f130
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: pUEvXftg5xCCVTHW_0W0A29nMsH8SkAFhwvONT-nB6g
+id: request_handler_mlt_default_7_0_0
+label: 'More Like This'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /mlt
+  class: solr.MoreLikeThisHandler
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: mlt.mintf
+          VALUE: '1'
+        -
+          name: mlt.mindf
+          VALUE: '1'
+        -
+          name: mlt.match.include
+          VALUE: 'false'
+        -
+          name: timeAllowed
+          VALUE: '${solr.mlt.timeAllowed:2000}'
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_query_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_query_default_7_0_0.yml
@@ -1,0 +1,31 @@
+uuid: 6961e6d3-03bb-43b3-9bf7-cf6947348140
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: mTtPKc0bQKmhHJjV1mFQ7yD806_uXWyXV8mmYirVY-c
+id: request_handler_query_default_7_0_0
+label: Query
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /select
+  class: solr.SearchHandler
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: echoParams
+          VALUE: explicit
+        -
+          name: wt
+          VALUE: json
+        -
+          name: indent
+          VALUE: 'true'
+        -
+          name: df
+          VALUE: id
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_replicationmaster_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_replicationmaster_default_7_0_0.yml
@@ -1,0 +1,31 @@
+uuid: 726957b4-c453-4a35-89ee-a6724be04b74
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: VzQZqpoqX7DQfyyACH6rTXbtkI6UnKPUquWqNhtKsCY
+id: request_handler_replicationmaster_default_7_0_0
+label: 'Replication Master'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_handler:
+  name: /replication
+  class: solr.ReplicationHandler
+  lst:
+    -
+      name: master
+      str:
+        -
+          name: enable
+          VALUE: '${solr.replication.master:false}'
+        -
+          name: replicateAfter
+          VALUE: commit
+        -
+          name: replicateAfter
+          VALUE: startup
+        -
+          name: confFiles
+          VALUE: '${solr.replication.confFiles:schema.xml,schema_extra_types.xml,schema_extra_fields.xml,elevate.xml}'
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_replicationslave_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_replicationslave_default_7_0_0.yml
@@ -1,0 +1,28 @@
+uuid: e7e47ea3-8957-4c7d-a63b-c76988a126d9
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: oLasTi84mXSOPlrp23tFSpNlHyzB-AaxcR60G0idwDY
+id: request_handler_replicationslave_default_7_0_0
+label: 'Replication Slave'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_handler:
+  name: /replication
+  class: solr.ReplicationHandler
+  lst:
+    -
+      name: slave
+      str:
+        -
+          name: enable
+          VALUE: '${solr.replication.slave:false}'
+        -
+          name: masterUrl
+          VALUE: '${solr.replication.masterUrl:http://localhost:8983/solr}/replication'
+        -
+          name: pollInterval
+          VALUE: '${solr.replication.pollInterval:00:00:60}'
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_select_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_select_default_7_0_0.yml
@@ -1,0 +1,45 @@
+uuid: 86ea6be6-1186-4340-a097-c4ea48384896
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: nx4cjhmOHhXQ6d5gnlM63v-zfbQmdeYi8pPV_4fiXf8
+id: request_handler_select_default_7_0_0
+label: Select
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /select
+  class: solr.SearchHandler
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: defType
+          VALUE: lucene
+        -
+          name: df
+          VALUE: id
+        -
+          name: echoParams
+          VALUE: explicit
+        -
+          name: omitHeader
+          VALUE: 'true'
+        -
+          name: timeAllowed
+          VALUE: '${solr.selectSearchHandler.timeAllowed:-1}'
+        -
+          name: spellcheck
+          VALUE: 'false'
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: spellcheck
+        -
+          VALUE: elevator
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_spell_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_spell_default_7_0_0.yml
@@ -1,0 +1,62 @@
+uuid: 08b0cc99-efb6-4b34-8c19-abdeafbf9743
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: K8FL_GAJEdbxEnnmGUmM69c7O38bwz66axaebjmsb4U
+id: request_handler_spell_default_7_0_0
+label: Spellcheck
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /spell
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: df
+          VALUE: id
+        -
+          name: spellcheck.dictionary
+          VALUE: und
+        -
+          name: spellcheck
+          VALUE: 'on'
+        -
+          name: spellcheck.onlyMorePopular
+          VALUE: 'false'
+        -
+          name: spellcheck.extendedResults
+          VALUE: 'false'
+        -
+          name: spellcheck.count
+          VALUE: '1'
+        -
+          name: spellcheck.alternativeTermCount
+          VALUE: '5'
+        -
+          name: spellcheck.maxResultsForSuggest
+          VALUE: '5'
+        -
+          name: spellcheck.collate
+          VALUE: 'true'
+        -
+          name: spellcheck.collateExtendedResults
+          VALUE: 'true'
+        -
+          name: spellcheck.maxCollationTries
+          VALUE: '10'
+        -
+          name: spellcheck.maxCollations
+          VALUE: '5'
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: spellcheck
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_suggest_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_suggest_default_7_0_0.yml
@@ -1,0 +1,35 @@
+uuid: df4c8253-278c-4643-9cb1-182340e53bd1
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: Mfa-0PxtXUpox8A8wb7DusQQwYl3vjQut09SkIr-OaA
+id: request_handler_suggest_default_7_0_0
+label: Suggester
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /suggest
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: suggest
+          VALUE: 'true'
+        -
+          name: suggest.dictionary
+          VALUE: und
+        -
+          name: suggest.dictionary
+          VALUE: '10'
+  arr:
+    -
+      name: components
+      str:
+        -
+          VALUE: suggest
+solr_configs: null

--- a/config/sync/search_api_solr.solr_request_handler.request_handler_tvrh_default_7_0_0.yml
+++ b/config/sync/search_api_solr.solr_request_handler.request_handler_tvrh_default_7_0_0.yml
@@ -1,0 +1,36 @@
+uuid: 386e8670-bfe1-422b-807b-e0ae30a3c565
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: dMZTGHu6VZtj5ks5N-ndQwAAr6PwcCIbFhsR1vnYhyQ
+id: request_handler_tvrh_default_7_0_0
+label: 'Term Vector'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /tvrh
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: df
+          VALUE: id
+        -
+          name: tv
+          VALUE: 'true'
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: tvComponent
+solr_configs:
+  searchComponents:
+    -
+      name: tvComponent
+      class: solr.TermVectorComponent


### PR DESCRIPTION
NB: There's quite a bit going on in the lock file here, so worth paying attention to that rather than the headline `composer.json` file.

Details as per one of the commits (left in git for historical reference):

```
Permits updates to:

- Search API 8.x-1.15
- Search API Solr 8.x-3.8 (1.x now unsupported)
- Solarium 5.1.5 (supported release)

See:

- https://www.drupal.org/project/search_api_solr/issues/3085196
- https://www.drupal.org/project/search_api_solr/issues/3085196#comment-13409794

Further reference:

- https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching

Related core issue (pending RTBC status):

- https://www.drupal.org/project/drupal/issues/2876675
```