### PR TITLE
D8NID 445 Extend basic_html filter allowed html list.

### DIFF
--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -21,7 +21,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <img src alt height width data-* typeof> <sup> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <drupal-entity data-* data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button alt title class> <picture data-* alt title class> <source srcset media type>'
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p translate> <br> <img src alt height width data-* typeof> <sup> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <drupal-entity data-* data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button alt title class> <picture data-* alt title class> <source srcset media type> <address>'
       filter_html_help: false
       filter_html_nofollow: false
   filter_align:


### PR DESCRIPTION
- Address element to allow for existing content using this.
- translate attribute on paragraph tag as this is used by accessibility
  tools to localise text; as found on the address field widget plugin
too.