### PR TITLE
D8NID-462 gp search results count

### DIFF
--- a/config/sync/views.view.gp_practices.yml
+++ b/config/sync/views.view.gp_practices.yml
@@ -266,27 +266,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
+          empty: true
           tokenize: false
           content:
             value: ''
             format: basic_html
           plugin_id: text
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '0 GP practices'
-            format: basic_html
-          plugin_id: text
+      empty: {  }
       relationships: {  }
       arguments: {  }
       display_extenders: {  }

--- a/config/sync/views.view.gp_practices_proximity.yml
+++ b/config/sync/views.view.gp_practices_proximity.yml
@@ -186,9 +186,7 @@ display:
           expose:
             label: ''
       title: 'Find a GP practice'
-      header: {  }
-      footer: {  }
-      empty:
+      header:
         area:
           id: area
           table: views
@@ -199,9 +197,11 @@ display:
           empty: true
           tokenize: false
           content:
-            value: '0 GP practices'
+            value: ''
             format: basic_html
           plugin_id: text
+      footer: {  }
+      empty: {  }
       relationships: {  }
       arguments:
         field_location_proximity:


### PR DESCRIPTION
Tokenised option in views config doesn't handler plurals, so we use a fixed empty header space and a preprocess hook in nidirect_gp.module to handle this for us. This PR is the views config