### PR TITLE
D8NID-500 Reinstate 'in this section' block

### DIFF
--- a/config/sync/block.block.inthissection.yml
+++ b/config/sync/block.block.inthissection.yml
@@ -1,0 +1,31 @@
+uuid: 2f1a62c3-b66c-4f6e-8843-3014d9e9ad76
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:basic:5622a22b-7e20-4c34-a332-1b600def9c4c'
+  module:
+    - block_content
+    - system
+  theme:
+    - nicsdru_nidirect_theme
+id: inthissection
+theme: nicsdru_nidirect_theme
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'block_content:5622a22b-7e20-4c34-a332-1b600def9c4c'
+settings:
+  id: 'block_content:5622a22b-7e20-4c34-a332-1b600def9c4c'
+  label: 'In this section'
+  provider: block_content
+  label_display: '0'
+  status: true
+  info: ''
+  view_mode: full
+visibility:
+  request_path:
+    id: request_path
+    pages: "/contacts\r\n/contacts/*"
+    negate: false
+    context_mapping: {  }


### PR DESCRIPTION
Reinstate block on contacts page (was working before but must have been lost when config was subsequently committed)