### PR TITLE
Fix prod services, remove unwanted db service and tweak QA env

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -19,14 +19,9 @@ relationships:
   redis: 'redis:redis'
   #  For MariaDB, the endpoint does not change whether you used the mysql or mariadb service type.
   database: 'db:admin'
-  drupal7db: 'drupal7db:mysql'
 
 # The size of the persistent disk of the application (in MB).
 disk: 20480
-
-runtime:
-  extensions:
-    - memcached
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
@@ -114,7 +109,7 @@ web:
     '/sites/default/files':
       # Allow access to all files in the public files directory.
       allow: true
-      expires: 5m
+      expires: 1d
       passthru: '/index.php'
       root: 'web/sites/default/files'
 

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -17,10 +17,6 @@ db:
         privileges:
           main: admin
 
-drupal7db:
-  type: mariadb:10.4
-  disk: 2048
-
 solr:
   type: solr:7.7
   disk: 1024

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -54,6 +54,13 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
     case 'master':
       // De-facto production settings.
       $config['config_split.config_split.production']['status'] = TRUE;
+      $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
+      break;
+
+    case (preg_match('/D8NID-qa/', getenv('PLATFORM_BRANCH'))):
+      // QA environment config adjustments.
+      $settings['simple_environment_indicator'] = '#e56716 QA';
+      break;
 
     default:
       // Default to use development settings/services for general platform.sh environments.


### PR DESCRIPTION
- Uses a regex to make sure the QA environment indicator is always set to a specific colour/title.
- Uses prod services config for caching/headers etc for a better likeness of the live environment.
- Drops the unwanted d7db service and memcache extension.