### PR TITLE
Fixes some environment indicator colours/titles

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -60,8 +60,12 @@ hooks:
     cd web
     # Rebuild caches, run db-updates and import config.
     drush -y cache-rebuild
+    # Temporarily unset config_readonly lock.
+    drush -y cset config_readonly 0
     drush -y updatedb
     drush -y config-import
+    # Reset config_readonly lock.
+    drush -y cset config_readonly 1
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -37,9 +37,6 @@ $settings['config_readonly_whitelist_patterns'] = [
   'system.site',
 ];
 
-// Environment indicator config.
-$settings['simple_environment_indicator'] = sprintf('%s %s', getenv('SIMPLEI_ENV_COLOUR'), getenv('SIMPLEI_ENV_NAME'));
-
 // Geocoder API key.
 $config['geolocation.settings']['google_map_api_key'] = getenv('GOOGLE_MAP_API_KEY');
 
@@ -49,6 +46,9 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
     include $app_root . '/' . $site_path . '/settings.platformsh.php';
   }
 
+  // Baseline environment indicator settings, can be overridden below.
+  $settings['simple_environment_indicator'] = sprintf('%s %s', getenv('SIMPLEI_ENV_COLOUR'), getenv('SIMPLEI_ENV_NAME'));
+
   // Environment specific settings and services.
   switch (getenv('PLATFORM_BRANCH')) {
     case 'master':
@@ -57,15 +57,16 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
       $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
       break;
 
-    case (preg_match('/D8NID-qa/', getenv('PLATFORM_BRANCH'))):
+    case (preg_match('/^D8NID-qa/i', getenv('PLATFORM_BRANCH'))):
       // QA environment config adjustments.
-      $settings['simple_environment_indicator'] = '#e56716 QA';
+      $settings['simple_environment_indicator'] = '#e56716 ' . getenv('PLATFORM_BRANCH');
       break;
 
     default:
       // Default to use development settings/services for general platform.sh environments.
       $config['config_split.config_split.development']['status'] = TRUE;
       $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.development.yml';
+      $settings['simple_environment_indicator'] = '#000000 ' . getenv('PLATFORM_BRANCH');
       include $app_root . '/' . $site_path . '/settings.development.php';
   }
 }

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -42,7 +42,7 @@ $config['geolocation.settings']['google_map_api_key'] = getenv('GOOGLE_MAP_API_K
 
 // Environment indicator defaults.
 $env_colour = '#000000';
-$env_name = getenv('SIMPLEI_ENV_NAME') ?? getenv('PLATFORM_BRANCH');
+$env_name = !empty(getenv('SIMPLEI_ENV_NAME')) ? getenv('SIMPLEI_ENV_NAME') : getenv('PLATFORM_BRANCH');
 
 // If we're running on platform.sh, check for and load relevant settings.
 if (!empty(getenv('PLATFORM_BRANCH'))) {

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -57,7 +57,7 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
       $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
       break;
 
-    case (preg_match('/^D8NID-qa/i', getenv('PLATFORM_BRANCH'))):
+    case (stripos(getenv('PLATFORM_BRANCH'), 'D8NID-qa') !== FALSE):
       // QA environment config adjustments.
       $settings['simple_environment_indicator'] = '#e56716 ' . getenv('PLATFORM_BRANCH');
       break;

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -40,14 +40,15 @@ $settings['config_readonly_whitelist_patterns'] = [
 // Geocoder API key.
 $config['geolocation.settings']['google_map_api_key'] = getenv('GOOGLE_MAP_API_KEY');
 
+// Environment indicator defaults.
+$env_colour = '#000000';
+$env_name = getenv('SIMPLEI_ENV_NAME') ?? getenv('PLATFORM_BRANCH');
+
 // If we're running on platform.sh, check for and load relevant settings.
 if (!empty(getenv('PLATFORM_BRANCH'))) {
   if (file_exists($app_root . '/' . $site_path . '/settings.platformsh.php')) {
     include $app_root . '/' . $site_path . '/settings.platformsh.php';
   }
-
-  // Baseline environment indicator settings, can be overridden below.
-  $settings['simple_environment_indicator'] = sprintf('%s %s', getenv('SIMPLEI_ENV_COLOUR'), getenv('SIMPLEI_ENV_NAME'));
 
   // Environment specific settings and services.
   switch (getenv('PLATFORM_BRANCH')) {
@@ -59,16 +60,17 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
 
     case (stripos(getenv('PLATFORM_BRANCH'), 'D8NID-qa') !== FALSE):
       // QA environment config adjustments.
-      $settings['simple_environment_indicator'] = '#e56716 ' . getenv('PLATFORM_BRANCH');
+      $env_colour = '#e56716';
       break;
 
     default:
       // Default to use development settings/services for general platform.sh environments.
       $config['config_split.config_split.development']['status'] = TRUE;
       $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.development.yml';
-      $settings['simple_environment_indicator'] = '#000000 ' . getenv('PLATFORM_BRANCH');
       include $app_root . '/' . $site_path . '/settings.development.php';
   }
+
+  $settings['simple_environment_indicator'] = sprintf('%s %s', $env_colour, $env_name);
 }
 
 // Local settings. These come last so that they can override anything.


### PR DESCRIPTION
Some provisional presets of colour/title:

- Prod: NIDirect blue, Live.
- QA: Orange, 'QA', only enables if 'D8NID-qa' (case insensitive) is found in the branch name.
- Lando/local: Green, 'Local'. Added by Lando as a settings.local.php override.
- Anything else: Black, branch name.