### PR TITLE
D8NID-485

### DIFF
--- a/config/sync/user.role.admin_user.yml
+++ b/config/sync/user.role.admin_user.yml
@@ -12,6 +12,7 @@ permissions:
   - 'access all webform results'
   - 'access ckeditor link'
   - 'access content overview'
+  - 'access document_entity_browser entity browser pages'
   - 'access draggableviews'
   - 'access library reports'
   - 'access media overview'

--- a/config/sync/user.role.author_user.yml
+++ b/config/sync/user.role.author_user.yml
@@ -11,6 +11,7 @@ permissions:
   - 'access administration pages'
   - 'access ckeditor link'
   - 'access content overview'
+  - 'access document_entity_browser entity browser pages'
   - 'access media overview'
   - 'access toolbar'
   - 'add media from remote sources'

--- a/config/sync/user.role.editor_user.yml
+++ b/config/sync/user.role.editor_user.yml
@@ -11,6 +11,7 @@ permissions:
   - 'access administration pages'
   - 'access ckeditor link'
   - 'access content overview'
+  - 'access document_entity_browser entity browser pages'
   - 'access draggableviews'
   - 'access media overview'
   - 'access taxonomy overview'

--- a/config/sync/user.role.supervisor_user.yml
+++ b/config/sync/user.role.supervisor_user.yml
@@ -11,6 +11,7 @@ permissions:
   - 'access administration pages'
   - 'access ckeditor link'
   - 'access content overview'
+  - 'access document_entity_browser entity browser pages'
   - 'access media overview'
   - 'access toolbar'
   - 'add content to books'


### PR DESCRIPTION
Give permission to use entity browser
(change made after ticket failed testing when editors and supervisors could not add attachments to publications)