### PR TITLE
Use search api tags to ensure search row render items are correctly expired when indexes are updated

### DIFF
--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -28,7 +28,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: tag
+        type: search_api_tag
         options: {  }
       query:
         type: views_query
@@ -666,8 +666,6 @@ display:
             multi_separator: ', '
           entity_type: node
           plugin_id: search_api_field
-      defaults:
-        fields: false
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Without this, default tag based caching means rows result stale render content after a Solr document is updated in the index.

Setting to search API tags keeps things in sync.