### PR TITLE
D8NID-558 improved geolocation address fields

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4706,17 +4706,17 @@
         },
         {
             "name": "drupal/geolocation",
-            "version": "3.0.0-rc7",
+            "version": "3.0.0-rc9",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/geolocation.git",
-                "reference": "8.x-3.0-rc7"
+                "reference": "8.x-3.0-rc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/geolocation-8.x-3.0-rc7.zip",
-                "reference": "8.x-3.0-rc7",
-                "shasum": "f09a9bee8f2250f0a06d2e84699c7eab15163743"
+                "url": "https://ftp.drupal.org/files/projects/geolocation-8.x-3.0-rc9.zip",
+                "reference": "8.x-3.0-rc9",
+                "shasum": "66d68d67c3f8292aeea1bd96f52ff1c827b2c77a"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9"
@@ -4727,6 +4727,7 @@
                 "drupal/geolocation_demo": "*",
                 "drupal/geolocation_geometry": "*",
                 "drupal/geolocation_geometry_data": "*",
+                "drupal/geolocation_geometry_natural_earth_countries": "*",
                 "drupal/geolocation_google_maps": "*",
                 "drupal/geolocation_google_maps_demo": "*",
                 "drupal/geolocation_google_static_maps": "*",
@@ -4737,12 +4738,9 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-3.0-rc7",
-                    "datestamp": "1585472288",
+                    "version": "8.x-3.0-rc9",
+                    "datestamp": "1586980843",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."

--- a/config/sync/core.entity_form_display.node.contact.default.yml
+++ b/config/sync/core.entity_form_display.node.contact.default.yml
@@ -26,6 +26,7 @@ dependencies:
     - content_moderation
     - datetime
     - field_group
+    - geolocation_address
     - geolocation_google_maps
     - link
     - metatag
@@ -57,8 +58,8 @@ third_party_settings:
       children:
         - field_contact_category
         - field_contact_group
-        - field_location
         - field_address
+        - field_location
         - field_email_address
         - field_telephone
         - field_contact_website
@@ -96,7 +97,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_address:
-    weight: 5
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: address_default
@@ -127,7 +128,7 @@ content:
     third_party_settings: {  }
   field_contact_hours:
     type: text_textarea
-    weight: 9
+    weight: 8
     region: content
     settings:
       rows: 5
@@ -135,7 +136,7 @@ content:
     third_party_settings: {  }
   field_contact_website:
     type: link_default
-    weight: 8
+    weight: 7
     region: content
     settings:
       placeholder_url: ''
@@ -143,7 +144,7 @@ content:
     third_party_settings: {  }
   field_email_address:
     type: email_default
-    weight: 6
+    weight: 5
     region: content
     settings:
       size: 60
@@ -152,10 +153,49 @@ content:
   field_location:
     weight: 4
     settings:
-      default_longitude: ''
-      default_latitude: ''
-      populate_address_field: '1'
-      target_address_field: field_address
+      centre:
+        client_location:
+          weight: 0
+          enable: false
+          map_center_id: client_location
+        fixed_boundaries:
+          settings:
+            north: ''
+            east: ''
+            south: ''
+            west: ''
+          weight: 0
+          enable: false
+          map_center_id: fixed_boundaries
+        fit_bounds:
+          enable: true
+          settings:
+            min_zoom: null
+            reset_zoom: false
+          weight: 0
+          map_center_id: fit_bounds
+        fixed_value:
+          settings:
+            latitude: null
+            longitude: null
+            location_option_id: fixed_value
+          weight: 0
+          enable: false
+          map_center_id: location_plugins
+        ipstack:
+          settings:
+            access_key: ''
+            location_option_id: ipstack
+          weight: 0
+          enable: false
+          map_center_id: location_plugins
+        freeogeoip:
+          weight: 0
+          enable: false
+          map_center_id: location_plugins
+          settings:
+            location_option_id: freeogeoip
+      auto_client_location_marker: '1'
       google_map_settings:
         height: 400px
         width: 100%
@@ -163,30 +203,268 @@ content:
         zoom: 10
         maxZoom: 18
         minZoom: 0
-        mapTypeControl: 1
-        streetViewControl: 1
-        zoomControl: 1
-        scrollwheel: 1
         gestureHandling: auto
-        draggable: 1
-        style: ''
-        info_auto_display: 1
-        marker_icon_path: ''
-        disableAutoPan: 1
-        rotateControl: false
-        fullscreenControl: 0
-        preferScrollingToZooming: 0
-        disableDoubleClickZoom: 0
-      auto_client_location: '0'
-      auto_client_location_marker: '0'
-      explicite_actions_address_field: '0'
+        map_features:
+          marker_infobubble:
+            weight: 0
+            settings:
+              close_other: 1
+              close_button_src: ''
+              shadow_style: 0
+              padding: 10
+              border_radius: 8
+              border_width: 2
+              border_color: '#039be5'
+              background_color: '#fff'
+              min_width: null
+              max_width: 550
+              min_height: null
+              max_height: null
+              arrow_style: 2
+              arrow_position: 30
+              arrow_size: 10
+              close_button: 0
+            enabled: false
+          control_streetview:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+              behavior: default
+            enabled: false
+          control_zoom:
+            enabled: true
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+              style: LARGE
+          map_restriction:
+            weight: 0
+            settings:
+              north: ''
+              south: ''
+              east: ''
+              west: ''
+              strict: true
+            enabled: false
+          map_type_style:
+            weight: 0
+            settings:
+              style: '[]'
+            enabled: false
+          marker_clusterer:
+            weight: 0
+            settings:
+              image_path: ''
+              styles: ''
+              zoom_on_click: true
+              grid_size: 60
+              minimum_cluster_size: 2
+              max_zoom: 15
+              average_center: false
+            enabled: false
+          marker_icon:
+            weight: 0
+            settings:
+              marker_icon_path: ''
+              anchor:
+                x: 0
+                'y': 0
+              origin:
+                x: 0
+                'y': 0
+              label_origin:
+                x: 0
+                'y': 0
+              size:
+                width: null
+                height: null
+              scaled_size:
+                width: null
+                height: null
+            enabled: false
+          marker_infowindow:
+            enabled: true
+            weight: 0
+            settings:
+              info_window_solitary: true
+              disable_auto_pan: true
+              max_width: null
+              info_auto_display: false
+          control_recenter:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+            enabled: false
+          marker_label:
+            weight: 0
+            settings:
+              color: ''
+              font_family: ''
+              font_size: ''
+              font_weight: ''
+            enabled: false
+          marker_opacity:
+            weight: 0
+            settings:
+              opacity: !!float 1
+            enabled: false
+          geolocation_marker_scroll_to_id:
+            weight: 0
+            settings:
+              scroll_target_id: ''
+            enabled: false
+          marker_zoom_to_animate:
+            weight: 0
+            settings:
+              marker_zoom_anchor_id: ''
+            enabled: false
+          spiderfying:
+            weight: 0
+            settings:
+              spiderfiable_marker_path: /modules/contrib/geolocation/modules/geolocation_google_maps/images/marker-plus.svg
+              markersWontMove: true
+              keepSpiderfied: true
+              nearbyDistance: 20
+              circleSpiralSwitchover: 9
+              circleFootSeparation: 23
+              spiralFootSeparation: 26
+              spiralLengthStart: 11
+              spiralLengthFactor: 4
+              legWeight: 1.5
+              markersWontHide: false
+              ignoreMapClick: false
+            enabled: false
+          google_maps_layer_traffic:
+            weight: 0
+            enabled: false
+          control_rotate:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+              behavior: default
+            enabled: false
+          control_maptype:
+            enabled: true
+            weight: 0
+            settings:
+              position: RIGHT_BOTTOM
+              behavior: default
+              style: DEFAULT
+          context_popup:
+            weight: 0
+            settings:
+              content:
+                value: ''
+                format: basic_html
+            enabled: false
+          google_maps_layer_bicycling:
+            weight: 0
+            enabled: false
+          client_location_indicator:
+            weight: 0
+            enabled: false
+          map_disable_tilt:
+            weight: 0
+            enabled: false
+          control_locate:
+            enabled: true
+            weight: 0
+            settings:
+              position: TOP_LEFT
+          map_disable_poi:
+            weight: 0
+            enabled: false
+          map_disable_user_interaction:
+            weight: 0
+            enabled: false
+          drawing:
+            weight: 0
+            settings:
+              strokeColor: '#FF0000'
+              strokeOpacity: '0.8'
+              strokeWeight: '2'
+              fillColor: '#FF0000'
+              fillOpacity: '0.35'
+              polyline: false
+              geodesic: false
+              polygon: false
+            enabled: false
+          control_fullscreen:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+              behavior: default
+            enabled: false
+          control_geocoder:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+              geocoder: google_geocoding_api
+              settings:
+                label: Address
+                description: 'Enter an address to be localized.'
+                autocomplete_min_length: 1
+                component_restrictions:
+                  route: ''
+                  locality: ''
+                  administrative_area: ''
+                  postal_code: ''
+                  country: ''
+                boundary_restriction:
+                  south: ''
+                  west: ''
+                  north: ''
+                  east: ''
+            enabled: false
+          control_loading_indicator:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+              loading_label: Loading
+            enabled: false
+          google_maps_layer_transit:
+            weight: 0
+            enabled: false
       allow_override_map_settings: 0
-    third_party_settings: {  }
+      hide_textfield_form: false
+      auto_client_location: ''
+    third_party_settings:
+      geolocation_address:
+        enable: true
+        address_field: field_address
+        geocoder: google_geocoding_api
+        settings:
+          label: Address
+          description: 'Enter an address to be localized.'
+          autocomplete_min_length: 1
+          component_restrictions:
+            route: ''
+            locality: ''
+            administrative_area: ''
+            postal_code: ''
+            country: UK
+          boundary_restriction:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+        sync_mode: auto
+        button_position: LEFT_TOP
+        direction: duplex
+        ignore:
+          organization: false
+          address-line1: false
+          address-line2: false
+          locality: false
+          administrative-area: false
+          postal-code: false
     type: geolocation_googlegeocoder
     region: content
   field_meta_tags:
     weight: 11
-    settings: {  }
+    settings:
+      sidebar: true
     third_party_settings: {  }
     type: metatag_firehose
     region: content
@@ -206,7 +484,7 @@ content:
     region: content
   field_site_themes:
     type: options_shs
-    weight: 10
+    weight: 9
     region: content
     settings:
       display_node_count: false
@@ -220,7 +498,7 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
+    type: string_textarea
     region: content
   field_supplementary_contact:
     type: string_textfield
@@ -231,7 +509,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_telephone:
-    weight: 7
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     type: telephone_plus_widget

--- a/config/sync/field.field.node.contact.field_location.yml
+++ b/config/sync/field.field.node.contact.field_location.yml
@@ -6,7 +6,25 @@ dependencies:
     - field.storage.node.field_location
     - node.type.contact
   module:
+    - geocoder_field
     - geolocation
+third_party_settings:
+  geocoder_field:
+    method: source
+    weight: 0
+    geocode_field: field_address
+    reverse_geocode_field: ''
+    skip_not_empty_value: 0
+    disabled: false
+    hidden: false
+    plugins:
+      - googlemaps
+    dumper: geolocation_geocoder_v3
+    delta_handling: default
+    failure:
+      handling: preserve
+      status_message: true
+      log: true
 id: node.contact.field_location
 field_name: field_location
 entity_type: node


### PR DESCRIPTION
- Sets the geolocation widget to the current user's location for new locations, if the browser permits it.
- Moves the address field above the geolocation field on contact nodes.
- Sets up automatic, full-duplex geocoding/sync between address and geolocation fields.