### PR TITLE
D8 nid 607

### DIFF
--- a/config/sync/core.entity_view_display.media.image.banner_deep.yml
+++ b/config/sync/core.entity_view_display.media.image.banner_deep.yml
@@ -1,0 +1,39 @@
+uuid: ddce8dab-bce6-4179-9a99-fc89400bf04d
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.banner_deep
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.deep_banner
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+_core:
+  default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
+id: media.image.banner_deep
+targetEntityType: media
+bundle: image
+mode: banner_deep
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      responsive_image_style: deep_banner
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.image.banner_thin.yml
+++ b/config/sync/core.entity_view_display.media.image.banner_thin.yml
@@ -1,0 +1,39 @@
+uuid: 50e3d187-df98-439c-b3e9-d3be31f914f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.banner_thin
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.thin_banner
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+_core:
+  default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
+id: media.image.banner_thin
+targetEntityType: media
+bundle: image
+mode: banner_thin
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      responsive_image_style: thin_banner
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.image.card_large.yml
+++ b/config/sync/core.entity_view_display.media.image.card_large.yml
@@ -1,0 +1,39 @@
+uuid: ce6a0184-fd4c-437e-80e4-3793453060f5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.card_large
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.card_large
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+_core:
+  default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
+id: media.image.card_large
+targetEntityType: media
+bundle: image
+mode: card_large
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      responsive_image_style: card_large
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.image.card_small.yml
+++ b/config/sync/core.entity_view_display.media.image.card_small.yml
@@ -1,0 +1,39 @@
+uuid: cc9acde6-6fcb-4569-99e9-a2c1cef7010b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.card_small
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.card_small
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+_core:
+  default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
+id: media.image.card_small
+targetEntityType: media
+bundle: image
+mode: card_small
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      responsive_image_style: card_small
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.image.feature_card.yml
+++ b/config/sync/core.entity_view_display.media.image.feature_card.yml
@@ -1,0 +1,39 @@
+uuid: 6f06d2c8-74bc-4059-8b8f-ed3280bfd4f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.feature_card
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.feature_card
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+_core:
+  default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
+id: media.image.feature_card
+targetEntityType: media
+bundle: image
+mode: feature_card
+content:
+  field_media_image:
+    label: visually_hidden
+    settings:
+      responsive_image_style: feature_card
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    weight: 1
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.feature.teaser.yml
+++ b/config/sync/core.entity_view_display.node.feature.teaser.yml
@@ -34,7 +34,7 @@ content:
     region: content
     label: hidden
     settings:
-      view_mode: embed
+      view_mode: feature_card
       link: false
     third_party_settings: {  }
   field_teaser:

--- a/config/sync/core.entity_view_display.node.health_condition.full.yml
+++ b/config/sync/core.entity_view_display.node.health_condition.full.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.node.health_condition.field_alternative_condition
     - field.field.node.health_condition.field_alternative_title
     - field.field.node.health_condition.field_banner_image
-    - field.field.node.health_condition.field_toc_enable
     - field.field.node.health_condition.field_hc_body_location
     - field.field.node.health_condition.field_hc_body_system
     - field.field.node.health_condition.field_hc_condition_type
@@ -32,11 +31,13 @@ dependencies:
     - field.field.node.health_condition.field_subtheme
     - field.field.node.health_condition.field_summary
     - field.field.node.health_condition.field_teaser
+    - field.field.node.health_condition.field_toc_enable
     - field.field.node.health_condition.field_top_level_theme
     - node.type.health_condition
   module:
     - layout_builder
     - link
+    - smart_trim
     - text
     - user
 third_party_settings:
@@ -51,22 +52,31 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 2
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     region: content
   field_hc_info_source:
     type: entity_reference_entity_view
-    weight: 4
+    weight: 5
     region: content
     label: hidden
     settings:
       link: true
       view_mode: default
     third_party_settings: {  }
+  field_photo:
+    type: entity_reference_entity_view
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      view_mode: embed
+      link: false
+    third_party_settings: {  }
   field_related_info:
     type: link
-    weight: 3
+    weight: 4
     region: content
     label: above
     settings:
@@ -77,12 +87,27 @@ content:
       target: ''
     third_party_settings: {  }
   field_summary:
-    weight: 0
+    weight: 1
     label: hidden
+    settings:
+      trim_length: 600
+      trim_type: chars
+      trim_suffix: ''
+      wrap_output: false
+      wrap_class: trimmed
+      more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: full
+      trim_options: {  }
+    third_party_settings: {  }
+    type: smart_trim
+    region: content
+  toc_display:
+    weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: text_default
-    region: content
 hidden:
   banner_display: true
   content_moderation_control: true
@@ -103,7 +128,6 @@ hidden:
   field_meta_tags: true
   field_next_review_date: true
   field_parent_condition: true
-  field_photo: true
   field_published_date: true
   field_related_conditions: true
   field_site_themes: true

--- a/config/sync/core.entity_view_mode.media.banner_deep.yml
+++ b/config/sync/core.entity_view_mode.media.banner_deep.yml
@@ -1,0 +1,10 @@
+uuid: 33026069-14f3-4770-a0a5-a372a09bc6a5
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.banner_deep
+label: 'Banner deep'
+targetEntityType: media
+cache: true

--- a/config/sync/core.entity_view_mode.media.banner_thin.yml
+++ b/config/sync/core.entity_view_mode.media.banner_thin.yml
@@ -1,0 +1,10 @@
+uuid: e73f43d2-7a13-42a8-86c4-8fa4dbabcf48
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.banner_thin
+label: 'Banner thin'
+targetEntityType: media
+cache: true

--- a/config/sync/core.entity_view_mode.media.card_large.yml
+++ b/config/sync/core.entity_view_mode.media.card_large.yml
@@ -1,0 +1,10 @@
+uuid: d17fa9a2-56e9-4ed9-8193-1e66ae17dcb0
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.card_large
+label: 'Card large'
+targetEntityType: media
+cache: true

--- a/config/sync/core.entity_view_mode.media.card_small.yml
+++ b/config/sync/core.entity_view_mode.media.card_small.yml
@@ -1,0 +1,10 @@
+uuid: 18ae47cd-1f04-490c-b8e3-0c1f7a9b569b
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.card_small
+label: 'Card small'
+targetEntityType: media
+cache: true

--- a/config/sync/core.entity_view_mode.media.feature_card.yml
+++ b/config/sync/core.entity_view_mode.media.feature_card.yml
@@ -1,0 +1,10 @@
+uuid: 479a6c4b-47b7-4c00-887d-116a9fb1263f
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.feature_card
+label: 'Feature card'
+targetEntityType: media
+cache: true


### PR DESCRIPTION
Creates and configures new media entity view modes needed to apply responsive image styles to media entity reference image fields (have assumed here that images in landing pages could be media entity reference fields).

Also changed the photo field on feature teaser display (/admin/structure/types/manage/feature/display/teaser) to use the new feature card display mode.

And also configured the photo field in health conditions full display mode to use the existing embed display mode.
