### PR TITLE
D8 nid 485 nocache

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -3,11 +3,7 @@
   type: upstream
   upstream: "nidirect:http"
   cache:
-    enabled: true
-    headers: ['Accept', 'Accept-Language', 'X-Language-Locale']
-    default_ttl: 3600
-    # Base the cache on the session cookie and custom Drupal cookies. Ignore all other cookies.
-    cookies: ['/^SS?ESS/', '/^Drupal.visitor/']
+    enabled: false
 
 "https://www.{default}/":
   type: redirect

--- a/config/development/system.performance.yml
+++ b/config/development/system.performance.yml
@@ -1,6 +1,6 @@
 cache:
   page:
-    max_age: 0
+    max_age: 86400
 css:
   preprocess: true
   gzip: true


### PR DESCRIPTION
Turn off Platform.sh default 'router cache' as it does not support push-based clearing.

This was causing several problems e.g. changes to a published node would not show until the cache expired, which could be up to a day.

In the long term, we intend to implement Fastly, and it would be good to set up a test instance before we go in to production.

In the meantime, the only other option really available to us is to configure Varnish, but this would involve a fair bit of effort that would be effectively time wasted.
