### PR TITLE
D8 nid 682 - help text for articles

### DIFF
--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -42,8 +42,8 @@ content:
     region: content
     settings:
       rows: 9
-      summary_rows: 3
       placeholder: ''
+      summary_rows: 3
       show_summary: false
     third_party_settings: {  }
   created:
@@ -58,7 +58,7 @@ content:
     region: content
     settings:
       rows: 5
-      placeholder: ''
+      placeholder: 'Optional footer text displayed at the bottom of the article. This will replace any footer text set in the parent theme/subtheme.'
     third_party_settings: {  }
   field_banner_image:
     weight: 4
@@ -119,7 +119,7 @@ content:
     weight: 7
     settings:
       rows: 5
-      placeholder: ''
+      placeholder: 'A short, relevant summary of what a page is about displayed below the page title and in search results.'
     third_party_settings: {  }
     type: string_textarea
     region: content
@@ -128,8 +128,8 @@ content:
     weight: 6
     region: content
     settings:
-      size: 60
-      placeholder: ''
+      size: 140
+      placeholder: 'A very short summary about the article (140 characters or less) that piques the reader''s interest.'
     third_party_settings: {  }
   field_toc_enable:
     type: boolean_checkbox

--- a/config/sync/field.field.node.article.field_summary.yml
+++ b/config/sync/field.field.node.article.field_summary.yml
@@ -10,7 +10,7 @@ field_name: field_summary
 entity_type: node
 bundle: article
 label: Summary
-description: 'A short, relevant summary of what a page is about.  It is displayed beneath the title and is also used as a description for search results. '
+description: ''
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.article.field_teaser.yml
+++ b/config/sync/field.field.node.article.field_teaser.yml
@@ -10,7 +10,7 @@ field_name: field_teaser
 entity_type: node
 bundle: article
 label: Teaser
-description: 'Enter a short teaser text of 140 characters to be displayed on topic listing pages.'
+description: 'Teaser text is often displayed with the article title and a "more" link on theme / campaign landing pages. '
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
Opening another PR on this.  Realised that #placeholder could be used for help text instead of or in addition to #description.  Placeholders have a restricted length - but have the advantage of (hopefully) being more visible and likely to be read by the user compared with descriptions which are shown after the field.