### PR TITLE
D8NID-684

### DIFF
--- a/config/sync/search_api.index.contacts.yml
+++ b/config/sync/search_api.index.contacts.yml
@@ -202,7 +202,7 @@ field_settings:
   title_fulltext:
     label: 'Title fulltext'
     property_path: aggregated_field
-    type: text
+    type: 'solr_text_custom:edge'
     boost: !!float 21
     configuration:
       type: concat


### PR DESCRIPTION
Changes to contact search:
- Change title field data type to 'fulltext edge' in contacts index so that searches match partial words 
e.g. searching for 'job' will return titles that contain 'Jobs'