### PR TITLE
D8NID-674 ckeditor refinement: fix drag 'n' drop issue

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -54,7 +54,7 @@ hooks:
     set -e
     bash install-redis.sh 5.1.1
     echo "Replace vanilla CKEditor config with a custom one to fix the click/drag bug with embedded entities"
-    git clone git@github.com:dof-dss/ckeditor4-fix-widget-dnd.git
+    git clone https://github.com/johangant/ckeditor4-fix-widget-dnd.git
     rm -rf web/core/assets/vendor/ckeditor
     mv ckeditor4-fix-widget-dnd/build/ckeditor web/core/assets/vendor/ckeditor
     rm -rf ckeditor4-fix-widget-dnd

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -53,6 +53,11 @@ hooks:
   build: |
     set -e
     bash install-redis.sh 5.1.1
+    echo "Replace vanilla CKEditor config with a custom one to fix the click/drag bug with embedded entities"
+    git clone git@github.com:dof-dss/ckeditor4-fix-widget-dnd.git
+    rm -rf web/core/assets/vendor/ckeditor
+    mv ckeditor4-fix-widget-dnd/build/ckeditor web/core/assets/vendor/ckeditor
+    rm -rf ckeditor4-fix-widget-dnd
   # The deploy hook runs after your application has been deployed and started.
   deploy: |
     set -e

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -54,7 +54,7 @@ hooks:
     set -e
     bash install-redis.sh 5.1.1
     echo "Replace vanilla CKEditor config with a custom one to fix the click/drag bug with embedded entities"
-    git clone https://github.com/johangant/ckeditor4-fix-widget-dnd.git
+    git clone https://github.com/dof-dss/ckeditor4-fix-widget-dnd.git
     rm -rf web/core/assets/vendor/ckeditor
     mv ckeditor4-fix-widget-dnd/build/ckeditor web/core/assets/vendor/ckeditor
     rm -rf ckeditor4-fix-widget-dnd


### PR DESCRIPTION
Holding the PR open: needs the git clone to use HTTPS instead of SSH for fewer unnecessary access control headaches.