### PR TITLE
D8NID-672 drop caching from media listing

### DIFF
--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -56,12 +56,17 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: full
         options:
           items_per_page: 24
           offset: 0
           id: 0
           total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -70,9 +75,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
+          quantity: 9
       style:
         type: default
         options:
@@ -1287,6 +1290,7 @@ display:
           plugin_id: rendered_entity
       defaults:
         fields: false
+        pager: true
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -35,7 +35,7 @@ display:
         options:
           perm: 'access media overview'
       cache:
-        type: tag
+        type: none
         options: {  }
       query:
         type: views_query


### PR DESCRIPTION
- Prioritise accuracy of usage over render efficiency.
- Default to full pager across all displays for consistency and ease of paging.