### PR TITLE
Refine spelling field parameters and field types

### DIFF
--- a/.platform/solr_config/schema.xml
+++ b/.platform/solr_config/schema.xml
@@ -154,6 +154,15 @@
   <field name="boost_document" type="pfloat" indexed="true" stored="false" multiValued="false" docValues="true"/>
   <field name="boost_term" type="boost_term_payload" indexed="true" stored="false" multiValued="true"/>
 
+  <!-- This field is used to build the spellchecker index -->
+  <field name="spell" type="text_spell_und" indexed="true" stored="true" multiValued="true"/>
+
+  <!-- copyField commands copy one field to another at the time a document
+       is added to the index.  It's used either to index the same field differently,
+       or to add multiple fields to the same field for easier/faster searching.  -->
+  <copyField source="ts_*" dest="spell"/>
+  <copyField source="tm_*" dest="spell"/>
+
   <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
        will be used if the name matches any of the patterns.
        RESTRICTION: the glob-like pattern in the name attribute must have

--- a/.platform/solr_config/schema_extra_types.xml
+++ b/.platform/solr_config/schema_extra_types.xml
@@ -48,7 +48,7 @@
     <tokenizer class="solr.WhitespaceTokenizerFactory"/>
     <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
     <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="1" protected="protwords_en.txt" splitOnCaseChange="0" generateWordParts="1" preserveOriginal="1" catenateAll="0" catenateWords="1"/>
-    <filter class="solr.LengthFilterFactory" min="2" max="100"/>
+    <filter class="solr.LengthFilterFactory" min="4" max="20"/>
     <filter class="solr.LowerCaseFilterFactory"/>
     <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords_en.txt"/>
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -59,7 +59,7 @@
     <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms_en.txt" expand="true" ignoreCase="true"/>
     <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
     <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="0" generateNumberParts="1" protected="protwords_en.txt" splitOnCaseChange="0" generateWordParts="1" preserveOriginal="1" catenateAll="0" catenateWords="0"/>
-    <filter class="solr.LengthFilterFactory" min="2" max="100"/>
+    <filter class="solr.LengthFilterFactory" min="4" max="20"/>
     <filter class="solr.LowerCaseFilterFactory"/>
     <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords_en.txt"/>
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -80,7 +80,7 @@
     <tokenizer class="solr.WhitespaceTokenizerFactory"/>
     <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
     <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="1" protected="protwords_en.txt" splitOnCaseChange="0" generateWordParts="1" preserveOriginal="1" catenateAll="0" catenateWords="1"/>
-    <filter class="solr.LengthFilterFactory" min="2" max="100"/>
+    <filter class="solr.LengthFilterFactory" min="4" max="20"/>
     <filter class="solr.LowerCaseFilterFactory"/>
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
@@ -90,7 +90,7 @@
     <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms_en.txt" expand="true" ignoreCase="true"/>
     <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
     <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="0" generateNumberParts="1" protected="protwords_en.txt" splitOnCaseChange="0" generateWordParts="1" preserveOriginal="1" catenateAll="0" catenateWords="0"/>
-    <filter class="solr.LengthFilterFactory" min="2" max="100"/>
+    <filter class="solr.LengthFilterFactory" min="4" max="20"/>
     <filter class="solr.LowerCaseFilterFactory"/>
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
@@ -150,20 +150,20 @@
 <fieldType name="text_und" class="solr.TextField" positionIncrementGap="100">
   <analyzer type="index">
     <charFilter class="solr.MappingCharFilterFactory" mapping="accents_und.txt"/>
-    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    <tokenizer class="solr.StandardTokenizerFactory"/>
     <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_und.txt"/>
     <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="1" generateNumberParts="1" protected="protwords_und.txt" splitOnCaseChange="0" generateWordParts="1" preserveOriginal="1" catenateAll="0" catenateWords="1"/>
-    <filter class="solr.LengthFilterFactory" min="2" max="100"/>
+    <filter class="solr.LengthFilterFactory" min="4" max="20"/>
     <filter class="solr.LowerCaseFilterFactory"/>
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
   <analyzer type="query">
     <charFilter class="solr.MappingCharFilterFactory" mapping="accents_und.txt"/>
-    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    <tokenizer class="solr.StandardTokenizerFactory"/>
     <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms_und.txt" expand="true" ignoreCase="true"/>
     <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_und.txt"/>
     <filter class="solr.WordDelimiterGraphFilterFactory" catenateNumbers="0" generateNumberParts="1" protected="protwords_und.txt" splitOnCaseChange="0" generateWordParts="1" preserveOriginal="1" catenateAll="0" catenateWords="0"/>
-    <filter class="solr.LengthFilterFactory" min="2" max="100"/>
+    <filter class="solr.LengthFilterFactory" min="4" max="20"/>
     <filter class="solr.LowerCaseFilterFactory"/>
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
@@ -173,13 +173,13 @@
   7.0.0
 -->
 <fieldType name="text_spell_und" class="solr.TextField" positionIncrementGap="100">
-  <analyzer>
-    <charFilter class="solr.MappingCharFilterFactory" mapping="accents_und.txt"/>
-    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-    <filter class="solr.LengthFilterFactory" min="2" max="100"/>
-    <filter class="solr.LowerCaseFilterFactory"/>
-    <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-  </analyzer>
+<analyzer>
+  <tokenizer class="solr.StandardTokenizerFactory" />
+  <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_und.txt"/>
+  <filter class="solr.LengthFilterFactory" min="4" max="20" />
+  <filter class="solr.LowerCaseFilterFactory" />
+  <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+</analyzer>
 </fieldType>
 <!--
   Language Undefined Text Field collated

--- a/.platform/solr_config/solrconfig_extra.xml
+++ b/.platform/solr_config/solrconfig_extra.xml
@@ -1,28 +1,30 @@
 <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+
 <!-- Ref: https://lucene.apache.org/solr/guide/7_7/spell-checking.html -->
     <lst name="spellchecker">
-      <str name="name">und</str>
-      <str name="field">spellcheck_und</str>
+<!--  Maps to field type in schema_extra_types.xml, eg: <fieldType name="text_spell_und" class="solr.TextField" positionIncrementGap="100"> -->
+      <str name="queryAnalyzerFieldType">text_spell_und</str>
+      <str name="name">spelling_und</str>
+<!--  Using copyField field in schema.xml-->
+      <str name="field">spell</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <str name="distanceMeasure">internal</str>
-      <str name="accuracy">0.25</str>
+<!--  Drop accurancy from default of 0.5 for more options-->
+      <str name="accuracy">0.01</str>
       <str name="maxEdits">2</str>
-      <str name="minPrefix">0</str>
-      <str name="maxInspections">5</str>
-      <str name="minQueryLength">2</str>
-      <str name="maxQueryFrequency">0.01</str>
-<!--Changed from default of .01-->
-      <str name="thresholdTokenFrequency">1</str>
-      <str name="onlyMorePopular">true</str>
-    </lst>
-
-    <lst name="spellchecker">
-      <str name="name">wordbreak</str>
-      <str name="classname">solr.WordBreakSolrSpellChecker</str>
-      <str name="field">spellcheck_und</str>
-      <str name="combineWords">true</str>
-      <str name="breakWords">true</str>
-      <int name="maxChanges">10</int>
+<!--  Must share at least one matching starting character-->
+      <str name="minPrefix">3</str>
+<!--  And be 3 chars or more -->
+      <str name="minQueryLength">3</str>
+      <!--  The maxInspections parameter defines the maximum number of possible matches to review before returning results; the default is 5-->
+      <str name="maxInspections">10</str>
+<!--  Query words, which are absent in the index or too rare ones (below maxQueryFrequency) are considered as misspelled-->
+<!--  Words which are more frequent than maxQueryFrequency bypass spellchecker unchanged -->
+      <str name="maxQueryFrequency">0.1</str>
+<!--  After suggestions for every misspelled word are found they are filtered for enough frequency with
+      thresholdTokenFrequency as boundary value. Default 0.1 -->
+      <str name="thresholdTokenFrequency">0.0001</str>
+      <str name="onlyMorePopular">false</str>
     </lst>
 
 </searchComponent>

--- a/.platform/solr_config/stopwords_en.txt
+++ b/.platform/solr_config/stopwords_en.txt
@@ -18,6 +18,7 @@ it
 no
 not
 of
+on
 or
 s
 such


### PR DESCRIPTION
Matches Lando configuration. Changes the way the spell field is built and stored in Solr, as well as how it's analysed/tokenized and fed back to the application.