### PR TITLE
Use grouped publish filter

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -567,48 +567,43 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: All
+          value: ''
           group: 1
           exposed: true
           expose:
             operator_id: ''
-            label: Status
-            description: ''
+            label: 'Published status'
+            description: null
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
-            required: false
+            required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              gp_author_user: '0'
-              author_user: '0'
-              gp_supervisor_user: '0'
-              news_supervisor: '0'
-              supervisor_user: '0'
-              editor_user: '0'
-              admin_user: '0'
-              apps_user: '0'
-              health_condition_author_user: '0'
-              health_condition_supervisor_user: '0'
-              driving_instructor_supervisor_user: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
+          is_grouped: true
           group_info:
-            label: ''
+            label: Status
             description: ''
-            identifier: ''
+            identifier: status
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
           entity_type: node
           entity_field: status
           plugin_id: boolean


### PR DESCRIPTION
Bring published/unpublished exposed filter on content admin screen into line with Drupal core i.e. make it a 'grouped' filter.
Also related to PR https://github.com/dof-dss/nicsdru_origins_modules/pull/72