### PR TITLE
D8NID-746 system time

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -125,15 +125,8 @@ web:
         '^/sites/default/files/(css|js)':
           expires: 2w
 
-# https://docs.platform.sh/languages/php/ini.html
-variables:
-  php:
-    "date.timezone": "Europe/London"
-
 # The configuration of scheduled execution.
 crons:
-  # https://docs.platform.sh/configuration/app/timezone.html#setting-the-system-timezone-for-cron-tasks
-  timezone: 'Europe/London'
   drupal:
     spec: '*/5 * * * *'
     cmd: 'cd web ; drush core-cron'

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -125,8 +125,15 @@ web:
         '^/sites/default/files/(css|js)':
           expires: 2w
 
+# https://docs.platform.sh/languages/php/ini.html
+variables:
+  php:
+    "date.timezone": "Europe/London"
+
 # The configuration of scheduled execution.
 crons:
   drupal:
+    # https://docs.platform.sh/configuration/app/timezone.html#setting-the-system-timezone-for-cron-tasks
+    timezone: 'Europe/London'
     spec: '*/5 * * * *'
     cmd: 'cd web ; drush core-cron'

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -132,8 +132,8 @@ variables:
 
 # The configuration of scheduled execution.
 crons:
+  # https://docs.platform.sh/configuration/app/timezone.html#setting-the-system-timezone-for-cron-tasks
+  timezone: 'Europe/London'
   drupal:
-    # https://docs.platform.sh/configuration/app/timezone.html#setting-the-system-timezone-for-cron-tasks
-    timezone: 'Europe/London'
     spec: '*/5 * * * *'
     cmd: 'cd web ; drush core-cron'

--- a/config/sync/system.date.yml
+++ b/config/sync/system.date.yml
@@ -2,9 +2,9 @@ country:
   default: ''
 first_day: 0
 timezone:
-  default: UTC
+  default: Europe/London
   user:
-    configurable: true
+    configurable: false
     warn: false
     default: 0
 _core:


### PR DESCRIPTION
Tell Drupal to handle our timezone: includes all aspect of date handling; UI, cron plugins etc.

All logs, underlying database timestamps and other deeper system service timestamps are stored in UTC as standard. That's actually very helpful when analysing dates across ranges that cross over BST.