### PR TITLE
Include LinkIt matcher for site themes

### DIFF
--- a/config/sync/linkit.linkit_profile.default.yml
+++ b/config/sync/linkit.linkit_profile.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - node
+    - taxonomy
 id: default
 label: Default
 description: ''
@@ -23,3 +24,12 @@ matchers:
       bundles: {  }
       group_by_bundle: true
       include_unpublished: false
+  494e7f56-8987-44de-9821-92a2e8ccd00b:
+    uuid: 494e7f56-8987-44de-9821-92a2e8ccd00b
+    id: 'entity:taxonomy_term'
+    weight: 0
+    settings:
+      result_description: ''
+      bundles:
+        site_themes: site_themes
+      group_by_bundle: true


### PR DESCRIPTION
Now provides site themes options for editors, like the one below:

![Screenshot 2020-06-23 at 14 56 11](https://user-images.githubusercontent.com/451261/85412647-b9b01000-b561-11ea-93bf-0311af830d95.png)
