### PR TITLE
D8NID-755 Enable origins metatag module + permission relating to it

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -106,6 +106,7 @@ module:
   origins_common: 0
   origins_form_descriptions: 0
   origins_layouts: 0
+  origins_metatag: 0
   origins_shamrock: 0
   origins_shamrock_admin: 0
   origins_social_sharing: 0

--- a/config/sync/user.role.editor_user.yml
+++ b/config/sync/user.role.editor_user.yml
@@ -312,6 +312,7 @@ permissions:
   - 'view any unpublished content'
   - 'view application revisions'
   - 'view article revisions'
+  - 'view basic meta tags'
   - 'view cold_weather_payment revisions'
   - 'view contact revisions'
   - 'view content references'


### PR DESCRIPTION
NB: CI will fail until composer.lock is updated to reflect a new release in https://github.com/dof-dss/nicsdru_origins_modules which is where the module providing this functionality exists.