### PR TITLE
D8NID-764 news queue

### DIFF
--- a/config/sync/core.entity_form_display.node.featured_content_list.default.yml
+++ b/config/sync/core.entity_form_display.node.featured_content_list.default.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   config:
     - field.field.node.featured_content_list.field_featured_content
+    - field.field.node.featured_content_list.field_subtheme
+    - field.field.node.featured_content_list.field_tags
     - node.type.featured_content_list
+    - workflows.workflow.nics_editorial_workflow
   module:
+    - chosen_field
     - content_moderation
     - scheduler
     - scheduler_content_moderation_integration
+    - shs
 id: node.featured_content_list.default
 targetEntityType: node
 bundle: featured_content_list
@@ -16,7 +21,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -30,26 +35,42 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_subtheme:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: chosen_select
+    region: content
+  field_tags:
+    weight: 3
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
+    third_party_settings: {  }
+    type: options_shs
+    region: content
   moderation_state:
     type: moderation_state_default
-    weight: 10
+    weight: 12
     settings: {  }
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 5
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 7
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -57,7 +78,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 13
     region: content
     third_party_settings: {  }
   title:
@@ -70,7 +91,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60
@@ -80,18 +101,18 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 6
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 8
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 9
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.featured_content_list.default.yml
+++ b/config/sync/core.entity_view_display.node.featured_content_list.default.yml
@@ -4,6 +4,8 @@ status: true
 dependencies:
   config:
     - field.field.node.featured_content_list.field_featured_content
+    - field.field.node.featured_content_list.field_subtheme
+    - field.field.node.featured_content_list.field_tags
     - node.type.featured_content_list
   module:
     - user
@@ -14,6 +16,22 @@ mode: default
 content:
   field_featured_content:
     weight: 0
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_subtheme:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_tags:
+    weight: 2
     label: above
     settings:
       link: true

--- a/config/sync/core.entity_view_display.node.featured_content_list.full.yml
+++ b/config/sync/core.entity_view_display.node.featured_content_list.full.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.featured_content_list.field_featured_content
+    - field.field.node.featured_content_list.field_subtheme
+    - field.field.node.featured_content_list.field_tags
     - node.type.featured_content_list
   module:
     - layout_builder
@@ -29,6 +31,8 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_subtheme: true
+  field_tags: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.featured_content_list.teaser.yml
+++ b/config/sync/core.entity_view_display.node.featured_content_list.teaser.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.featured_content_list.field_featured_content
+    - field.field.node.featured_content_list.field_subtheme
+    - field.field.node.featured_content_list.field_tags
     - node.type.featured_content_list
   module:
     - user
@@ -13,6 +15,11 @@ targetEntityType: node
 bundle: featured_content_list
 mode: teaser
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   links:
     weight: 100
     settings: {  }
@@ -20,5 +27,7 @@ content:
     region: content
 hidden:
   field_featured_content: true
+  field_subtheme: true
+  field_tags: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.featured_content_list.field_featured_content.yml
+++ b/config/sync/field.field.node.featured_content_list.field_featured_content.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_featured_content
     - node.type.feature
     - node.type.featured_content_list
+    - node.type.news
 id: node.featured_content_list.field_featured_content
 field_name: field_featured_content
 entity_type: node
@@ -21,8 +22,10 @@ settings:
   handler_settings:
     target_bundles:
       feature: feature
+      news: news
     sort:
-      field: _none
+      field: type
+      direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: feature
 field_type: entity_reference

--- a/config/sync/field.field.node.featured_content_list.field_subtheme.yml
+++ b/config/sync/field.field.node.featured_content_list.field_subtheme.yml
@@ -1,0 +1,29 @@
+uuid: c2bdc465-87e9-4ef8-83de-d828fce2fd15
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_subtheme
+    - node.type.featured_content_list
+    - taxonomy.vocabulary.site_themes
+id: node.featured_content_list.field_subtheme
+field_name: field_subtheme
+entity_type: node
+bundle: featured_content_list
+label: Theme/subtheme
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      site_themes: site_themes
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.featured_content_list.field_tags.yml
+++ b/config/sync/field.field.node.featured_content_list.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: c72450b6-5816-4b78-b56f-3b6d2f87dc8a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.featured_content_list
+    - taxonomy.vocabulary.tags
+id: node.featured_content_list.field_tags
+field_name: field_tags
+entity_type: node
+bundle: featured_content_list
+label: Tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_tags.yml
+++ b/config/sync/field.storage.node.field_tags.yml
@@ -1,0 +1,20 @@
+uuid: a2ef38de-4d08-45ee-82df-1ab01b2d650f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_tags
+field_name: field_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.news.yml
+++ b/config/sync/views.view.news.yml
@@ -13,7 +13,7 @@ dependencies:
 id: news
 label: News
 module: views
-description: ''
+description: 'Latest news listing: precise items/ordering fed in from nidirect_news.module'
 tag: ''
 base_table: node_field_data
 base_field: nid
@@ -114,19 +114,6 @@ display:
           separator: ', '
           field_api_classes: false
       filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
@@ -139,6 +126,46 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
       sorts:
         field_published_date_value:
           id: field_published_date_value
@@ -201,6 +228,8 @@ display:
         sorts: false
         css_class: false
         header: false
+        arguments: false
+        pager: false
       row:
         type: 'entity:node'
         options:
@@ -221,34 +250,54 @@ display:
             value: '<h2 class="visually-hidden">Featured news.</h2>'
             format: full_html
           plugin_id: text
-      sorts:
-        sticky:
-          id: sticky
+      sorts: {  }
+      arguments:
+        nid:
+          id: nid
           table: node_field_data
-          field: sticky
+          field: nid
           relationship: none
           group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
+          admin_label: 'List of news nids to display'
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:node'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              news: news
+            operation: view
+            multiple: 1
+            access: false
+          break_phrase: true
+          not: false
           entity_type: node
-          entity_field: sticky
-          plugin_id: standard
-        field_published_date_value:
-          id: field_published_date_value
-          table: node__field_published_date
-          field: field_published_date_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: datetime
+          entity_field: nid
+          plugin_id: node_nid
+      pager:
+        type: none
+        options:
+          offset: 0
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Adds:

- Two fields to the featured content list node type so that we can map them to existing site themes, or, some arbitrary tags for the pages that fall between the cracks such as homepage and news landing pages.

Relates to https://github.com/dof-dss/nidirect-site-modules/pull/187