### PR TITLE
Modifies quick publish workflow transition to allow published to published transition

### DIFF
--- a/config/sync/workflows.workflow.nics_editorial_workflow.yml
+++ b/config/sync/workflows.workflow.nics_editorial_workflow.yml
@@ -75,6 +75,7 @@ type_settings:
       label: 'Quick Publish'
       from:
         - draft
+        - published
       to: published
       weight: -1
     reject:


### PR DESCRIPTION
Editors have permissions to use the "quick publish" transition allowing them to create a draft and publish it, skipping the "needs review" moderation state.

However, when editing a published revision, editors would be forced to save the revision as a draft or "needs review" - they were not able to save the new revision as published.

This PR allows editors to edit a published revision and save the new revision as published.