### PR TITLE
D8NID-800 scheduled dev build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,11 +340,11 @@ workflows:
     triggers:
       - schedule:
           # At 00:00 on every day-of-week from Monday through Friday
-          cron: "0 12 * * 1-5"
+          cron: "0 0 * * 1-5"
           filters:
             branches:
               only:
-                - D8NID-800-nightly-build
+                - development
     jobs:
       - build
       - dev_build:
@@ -357,11 +357,11 @@ workflows:
   nightly-content-sync:
     triggers:
       - schedule:
-          # At 00:10 on every day-of-week from Monday through Friday
-          cron: "5 12 * * 1-5"
+          # At 00:30 on every day-of-week from Monday through Friday
+          cron: "30 0 * * 1-5"
           filters:
             branches:
               only:
-                - D8NID-800-nightly-build
+                - development
     jobs:
       - sync_data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ workflows:
     triggers:
       - schedule:
           # At 00:00 on every day-of-week from Monday through Friday
-          cron: "0 0 * * 1-5"
+          cron: "30 11 * * 1-5"
           filters:
             branches:
               only:
@@ -365,10 +365,10 @@ workflows:
     triggers:
       - schedule:
           # At 00:10 on every day-of-week from Monday through Friday
-          cron: "10 0 * * 1-5"
+          cron: "35 11 * * 1-5"
           filters:
             branches:
               only:
-                - D8NID-edge
+                - D8NID-800-nightly-build
     jobs:
       - sync_data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ commands:
           name: Add GitHub access token for composer
           command: echo 'composer config -g github-oauth.github.com $GITHUB_TOKEN' >> $BASH_ENV
       # Add SSH user key so we can access related repositories as part of our initial clone + composer install command.
-      # 89:cc >> GitHub user key fingerprint
-      # ed:e9 >> private fingerprint to talk to platform.sh
+      # 89:cc >> GitHub user key fingerprint.
+      # f8:f0 >> private fingerprint to allow Circle CI to talk to platform.sh.
       - add_ssh_keys:
           fingerprints:
             - "89:cc:6e:61:6a:0e:13:ab:47:0b:25:d6:bc:90:d4:d2"
-            - "ed:e9:03:7d:b2:e6:bc:92:f9:dc:78:62:00:cf:6e:e1"
+            - "f8:f0:34:a1:0e:51:56:44:2b:9c:db:b7:2f:26:3b:48"
       - checkout
   composer_tasks:
     description: "Validate and install dependencies using composer"
@@ -52,15 +52,16 @@ commands:
           command: |
             sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
             sudo apt-get update
-            sudo apt-get install -y libpng-dev
-            sudo docker-php-ext-install gd
+            sudo apt-get install -y libpng-dev mariadb-client rsync
+            sudo docker-php-ext-install gd pdo_mysql pcntl posix
             composer global require hirak/prestissimo
   github_hosts_workaround:
     description: "Adds github.com to known hosts in container; for working locally."
     steps:
       - run:
-          name: Keyscan Github (HACK)
+          name: Keyscan GitHub hostname
           command: mkdir -p ~/.ssh && ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
 jobs:
   # Tests the integrity of the build, stores the results in a workspace for re-use in later jobs.
   build:
@@ -74,6 +75,7 @@ jobs:
           root: ./
           paths:
             - ./
+
   # Test for coding standards and deprecated code.
   static_analysis:
     docker:
@@ -85,8 +87,8 @@ jobs:
           name: PHPCS static analysis
           command: /home/circleci/project/phpcs.sh /home/circleci/project "/home/circleci/project/web/modules/origins /home/circleci/project/web/modules/custom /home/circleci/project/web/modules/migrate /home/circleci/project/web/themes/custom"
       - run:
-         name: Deprecated code check
-         command: |
+          name: Deprecated code check
+          command: |
             cd /home/circleci/project
             vendor/bin/drupal-check /home/circleci/project/web/modules/custom /home/circleci/project/web/modules/origins
 
@@ -99,51 +101,48 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-            name: Add extra OS and PHP extensions/config
-            command: |
-              sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
-              sudo apt-get install -y libpng-dev mariadb-client rsync
-              sudo docker-php-ext-install gd pdo_mysql
+          name: Add extra OS and PHP extensions/config
+          command: |
+            sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
       - run:
-            name: Copy vhost into place
-            command: |
-              sudo cp .circleci/drupal.vhost /etc/apache2/sites-available/drupal.conf
+          name: Copy vhost into place
+          command: |
+            sudo cp .circleci/drupal.vhost /etc/apache2/sites-available/drupal.conf
       - run:
-            name: Enable web server and vhosts
-            command: |
-              sudo a2enmod rewrite
-              sudo a2dissite 000-default
-              sudo a2ensite drupal
-              sudo service apache2 start
+          name: Enable web server and vhosts
+          command: |
+            sudo a2enmod rewrite
+            sudo a2dissite 000-default
+            sudo a2ensite drupal
+            sudo service apache2 start
       - run:
-            name: Install Drupal and configure settings
-            command: |
-              # Should be scaffolded by now.
-              cd /home/circleci/project/web
-              cp sites/default/default.settings.php sites/default/settings.php
-              cp sites/default/default.services.yml sites/default/services.yml
-              # Copy in our environment specific settings to the settings.php file.
-              cp /home/circleci/project/.circleci/drupal.settings.php sites/default/settings.php
-              # Copy PHPUnit config into core folder.
-              cp /home/circleci/project/.circleci/phpunit.circleci.xml core/
-              # Install Drupal (or restore from DB dump at this point).
-              ../vendor/bin/drush site-install -y --existing-config
+          name: Install Drupal and configure settings
+          command: |
+            # Should be scaffolded by now.
+            cd /home/circleci/project/web
+            cp sites/default/default.settings.php sites/default/settings.php
+            cp sites/default/default.services.yml sites/default/services.yml
+            # Copy in our environment specific settings to the settings.php file.
+            cp /home/circleci/project/.circleci/drupal.settings.php sites/default/settings.php
+            # Copy PHPUnit config into core folder.
+            cp /home/circleci/project/.circleci/phpunit.circleci.xml core/
+            # Install Drupal (or restore from DB dump at this point).
+            ../vendor/bin/drush site-install -y --existing-config
       - run:
-            name: Copy files into webroot
-            command: |
-              # Copy our build into position (./ suffix ensures hidden files are copied too).
-              sudo rsync -avq /home/circleci/project/. /var/www/html
+          name: Copy files into webroot
+          command: |
+            # Copy our build into position (./ suffix ensures hidden files are copied too).
+            sudo rsync -avq /home/circleci/project/. /var/www/html
       - run:
-            name: PHPUnit tests (unit)
-            command: |
-              cd /var/www/html/web/core
-              ../../vendor/bin/phpunit -c /var/www/html/web/core/phpunit.circleci.xml --testsuite unit --group nidirect
+          name: PHPUnit tests (unit)
+          command: |
+            cd /var/www/html/web/core
+            ../../vendor/bin/phpunit -c /var/www/html/web/core/phpunit.circleci.xml --testsuite unit --group nidirect
       - run:
-            name: PHPUnit tests (kernel)
-            command: |
-              cd /var/www/html/web/core
-              ../../vendor/bin/phpunit -c /var/www/html/web/core/phpunit.circleci.xml --testsuite kernel --group nidirect
-
+          name: PHPUnit tests (kernel)
+          command: |
+            cd /var/www/html/web/core
+            ../../vendor/bin/phpunit -c /var/www/html/web/core/phpunit.circleci.xml --testsuite kernel --group nidirect
 
   # Functional tests with a JS browser; no content, only config.
   functional_js_tests__config_only:
@@ -168,8 +167,6 @@ jobs:
             sudo echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt-get update
             sudo apt-get install -y yarn
-            sudo docker-php-ext-install gd pdo_mysql
-            composer global require hirak/prestissimo
       - run:
           name: Copy vhost into place
           command: |
@@ -240,136 +237,87 @@ jobs:
       - run:
           name: Run functional tests with Nightwatch.js
           command: yarn --cwd=/var/www/html/web/core test:nightwatch ../modules/custom/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
-  # Deploy task.
-  deploy:
-    docker:
-      - image: circleci/php:7.3.14-apache-node-browsers
-    steps:
-      - checkout_code
-      - run:
-          name: Add platform.sh hosts to SSH known hosts
-          command: mkdir -p ~/.ssh && ssh-keyscan -H git.uk-1.platform.sh >> ~/.ssh/known_hosts
-      - run:
-          name: Relay to platform.sh
-          command: |
-            # Code is checked out under /home/circleci/project
-            cd /home/circleci/project
-            git remote add platform ${PLATFORM_REPO_URL}
-            git push -f platform ${CIRCLE_BRANCH}
 
-  # Our most expensive, full stack tests. Requires up to date content and services for chromedriver, yarn and database.
-  ui_tests:
+  # Deploy task.
+#  deploy:
+#    docker:
+#      - image: circleci/php:7.3.14-apache-node-browsers
+#    steps:
+#      - checkout_code
+#      - run:
+#          name: Add platform.sh hosts to SSH known hosts
+#          command: |
+#            mkdir -p ~/.ssh
+#            ssh-keyscan -H git.$PLATFORM_REGION >> ~/.ssh/known_hosts
+#      - run:
+#          name: Relay to platform.sh
+#          command: |
+#            # Code is checked out under /home/circleci/project
+#            cd /home/circleci/project
+#            git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
+#            git push -f psh ${CIRCLE_BRANCH}
+
+  # Development build: all dof-dss packages use HEAD on development branch, pushes to platform.sh repo.
+  dev_build:
     docker:
       - image: circleci/php:7.3.14-apache-node-browsers
-      - image: circleci/mysql:5.7.27
-      - image: drupalci/chromedriver:production
         environment:
-          CHROMEDRIVER_WHITELISTED_IPS: ""
-          CHROMEDRIVER_URL_BASE: "/wd/hub"
+          # git variables to avoid empty committer identity errors
+          EMAIL: "circleci@localhost"
+          GIT_COMMITTER_NAME: "Circle CI"
+          GIT_AUTHOR_NAME: "Circle CI"
     steps:
       - attach_workspace:
           at: ./
       - run:
-            name: Add OS and PHP extensions/config
-            command: |
-              # Add yarn deb repo.
-              curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-              sudo echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-              sudo apt-get install -y libpng-dev mariadb-client rsync gnupg apt-transport-https yarn
-              sudo docker-php-ext-install gd pdo_mysql
-              composer global require hirak/prestissimo
-      - run:
-            name: Copy vhost into place
-            command: |
-              sudo cp .circleci/drupal.vhost /etc/apache2/sites-available/drupal.conf
-      - run:
-            name: Enable web server and vhosts
-            command: |
-              sudo a2enmod rewrite
-              sudo a2dissite 000-default
-              sudo a2ensite drupal
-              sudo service apache2 start
-      - run:
-            name: Set up Drupal and configure settings
-            command: |
-              # Should be scaffolded by now.
-              cd /home/circleci/project/web
-              cp sites/default/default.settings.php sites/default/settings.php
-              cp sites/default/default.services.yml sites/default/services.yml
-              # Copy in our environment specific settings to the settings.php file.
-              cp /home/circleci/project/.circleci/drupal.settings.php sites/default/settings.php
-              # Copy PHPUnit config into core folder.
-              cp /home/circleci/project/.circleci/phpunit.circleci.xml core/
-              # Copy Nightwatch conf files into place.
-              cat core/.env.example | sed -e "s|\(^DRUPAL_TEST_BASE_URL\)\(.\+\)|\1=http:\/\/localhost|g" > core/.env
-              sed -i -e "s|\(#\)\(DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY\)=|\2=../|g" core/.env
-              sed -i -e "s|sqlite:\/\/localhost\/sites\/default\/files/db.sqlite|mysql://root:@127.0.0.1/circle_test|g" core/.env
-              sed -i -e "s|^DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=true|DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false|g" core/.env
-              sed -i -e "s|\(#\)\(DRUPAL_TEST_WEBDRIVER_CHROME_ARGS\)=|\2=\"--disable-gpu --headless --no-sandbox\"|g" core/.env
-              sed -i -e "s|\(^DRUPAL_NIGHTWATCH_OUTPUT\)=reports/nightwatch|\1=/home/circleci/nightwatch-reports|g" core/.env
-              mkdir -p /home/circleci/nightwatch-reports
-              # Install npm packages
-              cd /home/circleci/project/web/core
-              yarn install
-              cd /home/circleci/project/web/modules/custom
-              yarn install
-              cd /home/circleci/project/web/modules/migrate/nidirect-migrations/migrate_nidirect_node
-              yarn install
-
-              # Fetch database from our defined endpoint
-              git clone --depth=1 ${DB_SOURCE_URL} /home/circleci/dbs
-              # Restore to db service
-              cd /home/circleci/project/web
-              gzip -dc /home/circleci/dbs/nidirect--ui-test-sanitised.sql.gz | ../vendor/bin/drush sqlc
-              # Remove downloaded db file.
-              sudo rm -rf /home/circleci/dbs
-              # Clear caches/container rebuild for this environment.
-              ../vendor/bin/drush cr
-      - run:
-            name: Copy files into webroot
-            command: |
-              # Copy our build into position (./ suffix ensures hidden files are copied too).
-              sudo rsync -avq /home/circleci/project/. /var/www/html
-      - run:
-            name: UI tests with Nightwatch.js
-            command: yarn --cwd=/var/www/html/web/core test:nightwatch --skiptags core
-  # Debug job(s) - useful for working with circleci local which doesn't support caches or workspace persistence.
-  debug:
-    docker:
-      - image: circleci/php:7.3.14-apache-browsers
-    steps:
-      # Needed for circle ci local for some odd reason.
-      - github_hosts_workaround
-      - checkout_code
-      - install_php_os_extensions
-      - composer_tasks__no_cache
-      - run:
-          name: PHPCS static analysis
-          command: /home/circleci/project/phpcs.sh /home/circleci/project "/home/circleci/project/web/modules/origins /home/circleci/project/web/modules/custom /home/circleci/project/web/modules/migrate /home/circleci/project/web/themes/custom"
-      - run:
-          name: Deprecated code check
+          name: Keyscan Platform.sh region hostnames for password-less access
           command: |
-            cd /home/circleci/project
-            vendor/bin/drupal-check /home/circleci/project/web/modules/custom /home/circleci/project/web/modules/origins
+            mkdir -p ~/.ssh
+            ssh-keyscan -H ssh.$PLATFORM_REGION >> ~/.ssh/known_hosts
+            ssh-keyscan -H git.$PLATFORM_REGION >> ~/.ssh/known_hosts
+      - run:
+          name: Install the Platform.sh CLI tool
+          command: |
+            curl -sS https://platform.sh/cli/installer | php
+      - run:
+          name: Re-point dof-dss packages to use latest development code and push across to Platform.sh
+          command: |
+            cd ~/project
+            composer require dof-dss/nidirect-site-modules:dev-development dof-dss/nidirect-migrations:dev-development \
+              dof-dss/nidirect-d8-test-install-profile:dev-development dof-dss/nicsdru_origins_theme:dev-development \
+              dof-dss/nicsdru_origins_modules:dev-development dof-dss/nicsdru_nidirect_theme:dev-development
+
+            git add composer.*
+            git commit -m "Set dof-dss packages to HEAD development for build"
+            # Circle CI pushes direct into platform.sh repository. Any later commits via GitHub webhook
+            # integration will overwrite these changes. This approach means we can decouple our
+            # 'bleeding edge' package preferences here from our underlying codebase which will
+            # usually use tagged version of packages.
+            git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
+            # Always force push to a fixed branch on platform.sh.
+            git push -f psh $DEV_BUILD_BRANCH
+
 
 workflows:
   version: 2
   build-test-deploy:
     jobs:
       - build
-      - static_analysis:
-          requires:
-            - build
-      - unit_kernel_tests:
-          requires:
-            - build
-#      - functional_js_tests__config_only:
+#      - static_analysis:
 #          requires:
 #            - build
+#      - unit_kernel_tests:
+#          requires:
+#            - build
+      - dev_build:
+          requires:
+            - build
 #      - deploy:
 #          requires:
 #            - static_analysis
-##            - unit_kernel_tests
+#            - unit_kernel_tests
+#            - functional_tests
+
   nightly:
     triggers:
       - schedule:
@@ -381,6 +329,6 @@ workflows:
                 - development
     jobs:
       - build
-      - functional_js_tests__config_only:
+      -  dev_build:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,8 +300,6 @@ jobs:
     docker:
       - image: circleci/php:7.3.14-apache-browsers
     steps:
-      - attach_workspace:
-          at: ./
       - install_php_os_extensions
       - run:
           name: Add extra OS and PHP extensions/config
@@ -332,14 +330,12 @@ workflows:
 #      - unit_kernel_tests:
 #          requires:
 #            - build
-      - dev_build:
-          requires:
-            - build
-#            - static_analysis
-#            - unit_kernel_tests
-#      - sync_data:
+#      - dev_build:
 #          requires:
 #            - build
+#            - static_analysis
+#            - unit_kernel_tests
+      - sync_data
 
   nightly-edge-build:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ commands:
           name: Add GitHub access token for composer
           command: echo 'composer config -g github-oauth.github.com $GITHUB_TOKEN' >> $BASH_ENV
       # Add SSH user key so we can access related repositories as part of our initial clone + composer install command.
-      # 89:cc >> GitHub user key fingerprint.
       # f8:f0 >> private fingerprint to allow Circle CI to talk to platform.sh.
+      # 89:cc >> GitHub user key fingerprint.
       - add_ssh_keys:
           fingerprints:
-            - "89:cc:6e:61:6a:0e:13:ab:47:0b:25:d6:bc:90:d4:d2"
             - "f8:f0:34:a1:0e:51:56:44:2b:9c:db:b7:2f:26:3b:48"
+            - "89:cc:6e:61:6a:0e:13:ab:47:0b:25:d6:bc:90:d4:d2"
       - checkout
   composer_tasks:
     description: "Validate and install dependencies using composer"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,17 +284,21 @@ jobs:
           name: Re-point dof-dss packages to use latest development code and push across to Platform.sh
           command: |
             cd ~/project
+            git checkout -b $DEV_BUILD_BRANCH
+            
+            # Circle CI pushes direct into platform.sh repository. Any later commits via GitHub webhook
+            # integration will overwrite these changes. This approach means we can decouple our
+            # 'bleeding edge' package preferences here from our underlying codebase which will
+            # usually use tagged version of packages.
+            git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
+
             composer require dof-dss/nidirect-site-modules:dev-development dof-dss/nidirect-migrations:dev-development \
               dof-dss/nidirect-d8-test-install-profile:dev-development dof-dss/nicsdru_origins_theme:dev-development \
               dof-dss/nicsdru_origins_modules:dev-development dof-dss/nicsdru_nidirect_theme:dev-development
 
             git add composer.*
             git commit -m "Set dof-dss packages to HEAD development for build"
-            # Circle CI pushes direct into platform.sh repository. Any later commits via GitHub webhook
-            # integration will overwrite these changes. This approach means we can decouple our
-            # 'bleeding edge' package preferences here from our underlying codebase which will
-            # usually use tagged version of packages.
-            git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
+
             # Always force push to a fixed branch on platform.sh.
             git push -f psh $DEV_BUILD_BRANCH
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,11 @@ jobs:
             cd ~/project
             git checkout -b $DEV_BUILD_BRANCH
 
+            # Activate SSH keys on Platform.sh with initial forced deployment.
+            # https://docs.platform.sh/development/ssh.html#still-having-trouble
+            git commit --allow-empty -m 'force redeploy'
+            git push origin $DEV_BUILD_BRANCH
+
             # Circle CI pushes direct into platform.sh repository. Any later commits via GitHub webhook
             # integration will overwrite these changes. This approach means we can decouple our
             # 'bleeding edge' package preferences here from our underlying codebase which will

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,38 +284,64 @@ jobs:
             # Push to fixed, non-integrating build branch. GitHub webhook integration will propagate this
             # to platform.sh for later steps to use.
             git push -f origin $DEV_BUILD_BRANCH
+
+            # Pause for webhook to propagate the change from GH to PSH.
+            sleep 10s
       - run:
-          name: Pause for webhook activity
-          command: sleep 10s
-      - run:
-          name: Re-sync data from master environment / activate if not found.
+          name: Activate the environment if not found.
           command: |
-            if /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $DEV_BUILD_BRANCH; then
-              echo "Sync data from master environment to $DEV_BUILD_BRANCH"
-              /home/circleci/.platformsh/bin/platform sync data -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
-            else
+            if ! /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $DEV_BUILD_BRANCH; then
               echo "No active environment for $DEV_BUILD_BRANCH found, attempt to activate one."
               /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
             fi
+
+  # Separate task to allow us to sync data on PSH environments, without pauses in other jobs.
+  sync_data:
+    docker:
+      - image: circleci/php:7.3.14-apache-browsers
+    steps:
+      - attach_workspace:
+          at: ./
+      - install_php_os_extensions
+      - run:
+          name: Add extra OS and PHP extensions/config
+          command: |
+            sudo docker-php-ext-install pcntl posix
+      - run:
+          name: Keyscan Platform.sh region hostnames for password-less access
+          command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan -H ssh.$PLATFORM_REGION >> ~/.ssh/known_hosts
+      - run:
+          name: Install the Platform.sh CLI tool
+          command: |
+            curl -sS https://platform.sh/cli/installer | php
+      - run:
+          name: Trigger a data sync from master environment to nightly edge build.
+          command: |
+            /home/circleci/.platformsh/bin/platform sync data -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
 
 workflows:
   version: 2
   build-test-deploy:
     jobs:
       - build
-      - static_analysis:
-          requires:
-            - build
-      - unit_kernel_tests:
-          requires:
-            - build
+#      - static_analysis:
+#          requires:
+#            - build
+#      - unit_kernel_tests:
+#          requires:
+#            - build
       - dev_build:
           requires:
             - build
-            - static_analysis
-            - unit_kernel_tests
+#            - static_analysis
+#            - unit_kernel_tests
+#      - sync_data:
+#          requires:
+#            - build
 
-  nightly:
+  nightly-edge-build:
     triggers:
       - schedule:
           # At 00:00 on every day-of-week from Monday through Friday
@@ -334,6 +360,17 @@ workflows:
             - build
       - dev_build:
           requires:
-            - build
             - static_analysis
             - unit_kernel_tests
+
+  nightly-content-sync:
+    triggers:
+      - schedule:
+          # At 00:10 on every day-of-week from Monday through Friday
+          cron: "10 0 * * 1-5"
+          filters:
+            branches:
+              only:
+                - development
+    jobs:
+      - sync_data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,18 +284,18 @@ jobs:
           name: Re-point dof-dss packages to use latest development code and push across to Platform.sh
           command: |
             cd ~/project
-            git checkout -b $DEV_BUILD_BRANCH
-
-            # Activate SSH keys on Platform.sh with initial forced deployment.
-            # https://docs.platform.sh/development/ssh.html#still-having-trouble
-            git commit --allow-empty -m 'force redeploy'
-            git push origin $DEV_BUILD_BRANCH
-
             # Circle CI pushes direct into platform.sh repository. Any later commits via GitHub webhook
             # integration will overwrite these changes. This approach means we can decouple our
             # 'bleeding edge' package preferences here from our underlying codebase which will
             # usually use tagged version of packages.
             git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
+
+            git checkout -b $DEV_BUILD_BRANCH
+
+            # Activate SSH keys on Platform.sh with initial forced deployment.
+            # https://docs.platform.sh/development/ssh.html#still-having-trouble
+            git commit --allow-empty -m 'force redeploy'
+            git push psh $DEV_BUILD_BRANCH
 
             composer require dof-dss/nidirect-site-modules:dev-development dof-dss/nidirect-migrations:dev-development \
               dof-dss/nidirect-d8-test-install-profile:dev-development dof-dss/nicsdru_origins_theme:dev-development \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,8 @@ commands:
 jobs:
   # Tests the integrity of the build, stores the results in a workspace for re-use in later jobs.
   build:
-    docker:
-      - image: circleci/php:7.3.14-apache-browsers
+    machine:
+      image: ubuntu-1604:202007-01
     steps:
       - checkout_code
       - install_php_os_extensions
@@ -259,16 +259,17 @@ jobs:
 
   # Development build: all dof-dss packages use HEAD on development branch, pushes to platform.sh repo.
   dev_build:
-    docker:
-      - image: circleci/php:7.3.14-apache-node-browsers
-        environment:
-          # git variables to avoid empty committer identity errors
-          EMAIL: "circleci@localhost"
-          GIT_COMMITTER_NAME: "Circle CI"
-          GIT_AUTHOR_NAME: "Circle CI"
+    machine:
+      image: ubuntu-1604:202007-01
+    environment:
+      # git variables to avoid empty committer identity errors
+      EMAIL: "circleci@localhost"
+      GIT_COMMITTER_NAME: "Circle CI"
+      GIT_AUTHOR_NAME: "Circle CI"
     steps:
       - attach_workspace:
           at: ./
+      - install_php_os_extensions
       - run:
           name: Keyscan Platform.sh region hostnames for password-less access
           command: |
@@ -296,6 +297,10 @@ jobs:
             git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
             # Always force push to a fixed branch on platform.sh.
             git push -f psh $DEV_BUILD_BRANCH
+      - run:
+          name: Re-sync data from master environment
+          command: |
+            /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH -y
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,8 @@ commands:
 jobs:
   # Tests the integrity of the build, stores the results in a workspace for re-use in later jobs.
   build:
-    machine:
-      image: ubuntu-1604:202007-01
+    docker:
+      - image: circleci/php:7.3.14-apache-browsers
     steps:
       - checkout_code
       - install_php_os_extensions
@@ -259,8 +259,8 @@ jobs:
 
   # Development build: all dof-dss packages use HEAD on development branch, pushes to platform.sh repo.
   dev_build:
-    machine:
-      image: ubuntu-1604:202007-01
+    docker:
+      - image: circleci/php:7.3.14-apache-browsers
     environment:
       # git variables to avoid empty committer identity errors
       EMAIL: "circleci@localhost"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,23 +340,16 @@ workflows:
     triggers:
       - schedule:
           # At 00:00 on every day-of-week from Monday through Friday
-          cron: "30 11 * * 1-5"
+          cron: "0 12 * * 1-5"
           filters:
             branches:
               only:
                 - D8NID-800-nightly-build
     jobs:
       - build
-      - static_analysis:
-          requires:
-            - build
-      - unit_kernel_tests:
-          requires:
-            - build
       - dev_build:
           requires:
-            - static_analysis
-            - unit_kernel_tests
+            - build
 
   # A separate scheduled workflow to sync the data after the nightly build completes.
   # This is separate to avoid using build time/compute units with arbitrary sleep commands;
@@ -365,7 +358,7 @@ workflows:
     triggers:
       - schedule:
           # At 00:10 on every day-of-week from Monday through Friday
-          cron: "35 11 * * 1-5"
+          cron: "5 12 * * 1-5"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,8 +241,8 @@ jobs:
           name: Run functional tests with Nightwatch.js
           command: yarn --cwd=/var/www/html/web/core test:nightwatch ../modules/custom/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
 
-  # Development build: all dof-dss packages use HEAD on development branch, pushes to fixed non-integrating branch.
-  dev_build:
+  # Edge build: all dof-dss packages use HEAD on development branch, pushes to fixed non-integrating branch.
+  edge_build:
     docker:
       - image: circleci/php:7.3.14-apache-browsers
     environment:
@@ -272,7 +272,7 @@ jobs:
           name: Re-point dof-dss packages to use latest development code and push.
           command: |
             cd ~/project
-            git checkout -b $DEV_BUILD_BRANCH
+            git checkout -b $EDGE_BUILD_BRANCH
 
             composer require dof-dss/nidirect-site-modules:dev-development dof-dss/nidirect-migrations:dev-development \
               dof-dss/nidirect-d8-test-install-profile:dev-development dof-dss/nicsdru_origins_theme:dev-development \
@@ -283,16 +283,16 @@ jobs:
 
             # Push to fixed, non-integrating build branch. GitHub webhook integration will propagate this
             # to platform.sh for later steps to use.
-            git push -f origin $DEV_BUILD_BRANCH
+            git push -f origin $EDGE_BUILD_BRANCH
 
             # Pause for webhook to propagate the change from GH to PSH.
             sleep 10s
       - run:
           name: Activate the environment if not found.
           command: |
-            if ! /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $DEV_BUILD_BRANCH; then
-              echo "No active environment for $DEV_BUILD_BRANCH found, attempt to activate one."
-              /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
+            if ! /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $EDGE_BUILD_BRANCH; then
+              echo "No active environment for $EDGE_BUILD_BRANCH found, attempt to activate one."
+              /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH -y
             fi
 
   # Separate task to allow us to sync data on PSH environments, without pauses in other jobs.
@@ -318,7 +318,7 @@ jobs:
       - run:
           name: Trigger a data sync from master environment to nightly edge build.
           command: |
-            /home/circleci/.platformsh/bin/platform sync data -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
+            /home/circleci/.platformsh/bin/platform sync data -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH -y
 
 workflows:
   version: 2
@@ -347,7 +347,7 @@ workflows:
                 - development
     jobs:
       - build
-      - dev_build:
+      - edge_build:
           requires:
             - build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ commands:
           command: |
             sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
             sudo apt-get update
-            sudo apt-get install -y libpng-dev mariadb-client rsync
-            sudo docker-php-ext-install gd pdo_mysql pcntl posix
+            sudo apt-get install -y libpng-dev
+            sudo docker-php-ext-install gd
             composer global require hirak/prestissimo
   github_hosts_workaround:
     description: "Adds github.com to known hosts in container; for working locally."
@@ -104,6 +104,8 @@ jobs:
           name: Add extra OS and PHP extensions/config
           command: |
             sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
+            sudo apt-get install -y libpng-dev mariadb-client rsync
+            sudo docker-php-ext-install gd pdo_mysql
       - run:
           name: Copy vhost into place
           command: |
@@ -167,6 +169,7 @@ jobs:
             sudo echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt-get update
             sudo apt-get install -y yarn
+            sudo docker-php-ext-install gd pdo_mysql
       - run:
           name: Copy vhost into place
           command: |
@@ -251,6 +254,10 @@ jobs:
       - attach_workspace:
           at: ./
       - install_php_os_extensions
+      - run:
+          name: Add extra OS and PHP extensions/config
+          command: |
+            sudo docker-php-ext-install pcntl posix
       - run:
           name: Keyscan Platform.sh region hostnames + GitHub for password-less access
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,10 +300,12 @@ jobs:
     docker:
       - image: circleci/php:7.3.14-apache-browsers
     steps:
+      - checkout_code
+      - install_php_os_extensions
       - run:
           name: Add extra OS and PHP extensions/config
           command: |
-            sudo docker-php-ext-install gd pcntl posix
+            sudo docker-php-ext-install pcntl posix
       - run:
           name: Keyscan Platform.sh region hostnames for password-less access
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
 #            git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
 #            git push -f psh ${CIRCLE_BRANCH}
 
-  # Development build: all dof-dss packages use HEAD on development branch, pushes to platform.sh repo.
+  # Development build: all dof-dss packages use HEAD on development branch, pushes to fixed non-integrating branch.
   dev_build:
     docker:
       - image: circleci/php:7.3.14-apache-browsers
@@ -271,31 +271,20 @@ jobs:
           at: ./
       - install_php_os_extensions
       - run:
-          name: Keyscan Platform.sh region hostnames for password-less access
+          name: Keyscan Platform.sh region hostnames + GitHub for password-less access
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan -H ssh.$PLATFORM_REGION >> ~/.ssh/known_hosts
-            ssh-keyscan -H git.$PLATFORM_REGION >> ~/.ssh/known_hosts
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run:
           name: Install the Platform.sh CLI tool
           command: |
             curl -sS https://platform.sh/cli/installer | php
       - run:
-          name: Re-point dof-dss packages to use latest development code and push across to Platform.sh
+          name: Re-point dof-dss packages to use latest development code and push.
           command: |
             cd ~/project
-            # Circle CI pushes direct into platform.sh repository. Any later commits via GitHub webhook
-            # integration will overwrite these changes. This approach means we can decouple our
-            # 'bleeding edge' package preferences here from our underlying codebase which will
-            # usually use tagged version of packages.
-            git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
-
             git checkout -b $DEV_BUILD_BRANCH
-
-            # Activate SSH keys on Platform.sh with initial forced deployment.
-            # https://docs.platform.sh/development/ssh.html#still-having-trouble
-            git commit --allow-empty -m 'force redeploy'
-            git push psh $DEV_BUILD_BRANCH
 
             composer require dof-dss/nidirect-site-modules:dev-development dof-dss/nidirect-migrations:dev-development \
               dof-dss/nidirect-d8-test-install-profile:dev-development dof-dss/nicsdru_origins_theme:dev-development \
@@ -304,14 +293,20 @@ jobs:
             git add composer.*
             git commit -m "Set dof-dss packages to HEAD development for build"
 
-            # Always force push to a fixed branch on platform.sh.
-            git push -f psh $DEV_BUILD_BRANCH
+            # Push to fixed, non-integrating build branch. GitHub webhook integration will propagate this
+            # to platform.sh for later steps to use.
+            git push -f origin $DEV_BUILD_BRANCH
+      - run:
+          name: Pause for webhook activity
+          command: sleep 10s
       - run:
           name: Re-sync data from master environment / activate if not found.
           command: |
             if /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $DEV_BUILD_BRANCH; then
-              echo "Found existing active environment for $DEV_BUILD_BRANCH"
+              echo "Sync data from master environment to $DEV_BUILD_BRANCH"
+              /home/circleci/.platformsh/bin/platform sync data -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
             else
+              echo "No active environment for $DEV_BUILD_BRANCH found, attempt to activate one."
               /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,10 +302,13 @@ jobs:
             # Always force push to a fixed branch on platform.sh.
             git push -f psh $DEV_BUILD_BRANCH
       - run:
-          name: Re-sync data from master environment
+          name: Re-sync data from master environment / activate if not found.
           command: |
-            /home/circleci/.platformsh/bin/platform sync data -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
-
+            if /home/circleci/.platformsh/bin/platform environment:list -p $PLATFORM_PROJECT_ID -I --no-header --pipe | grep -q $DEV_BUILD_BRANCH; then
+              echo "Found existing active environment for $DEV_BUILD_BRANCH"
+            else
+              /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,25 +238,6 @@ jobs:
           name: Run functional tests with Nightwatch.js
           command: yarn --cwd=/var/www/html/web/core test:nightwatch ../modules/custom/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
 
-  # Deploy task.
-#  deploy:
-#    docker:
-#      - image: circleci/php:7.3.14-apache-node-browsers
-#    steps:
-#      - checkout_code
-#      - run:
-#          name: Add platform.sh hosts to SSH known hosts
-#          command: |
-#            mkdir -p ~/.ssh
-#            ssh-keyscan -H git.$PLATFORM_REGION >> ~/.ssh/known_hosts
-#      - run:
-#          name: Relay to platform.sh
-#          command: |
-#            # Code is checked out under /home/circleci/project
-#            cd /home/circleci/project
-#            git remote add psh $PLATFORM_PROJECT_ID@git.$PLATFORM_REGION:$PLATFORM_PROJECT_ID.git
-#            git push -f psh ${CIRCLE_BRANCH}
-
   # Development build: all dof-dss packages use HEAD on development branch, pushes to fixed non-integrating branch.
   dev_build:
     docker:
@@ -315,20 +296,17 @@ workflows:
   build-test-deploy:
     jobs:
       - build
-#      - static_analysis:
-#          requires:
-#            - build
-#      - unit_kernel_tests:
-#          requires:
-#            - build
+      - static_analysis:
+          requires:
+            - build
+      - unit_kernel_tests:
+          requires:
+            - build
       - dev_build:
           requires:
             - build
-#      - deploy:
-#          requires:
-#            - static_analysis
-#            - unit_kernel_tests
-#            - functional_tests
+            - static_analysis
+            - unit_kernel_tests
 
   nightly:
     triggers:
@@ -341,6 +319,14 @@ workflows:
                 - development
     jobs:
       - build
-      -  dev_build:
+      - static_analysis:
           requires:
             - build
+      - unit_kernel_tests:
+          requires:
+            - build
+      - dev_build:
+          requires:
+            - build
+            - static_analysis
+            - unit_kernel_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,22 +322,20 @@ jobs:
 
 workflows:
   version: 2
+  # Our default pipeline that tests the integrity of our build + any tests.
+  # TODO: integrate a deploy job so that Circle CI can relay changes across to platform.sh
+  # rather than rely on the present webhook integration between GitHub and platform.sh repos.
   build-test-deploy:
     jobs:
-#      - build
-#      - static_analysis:
-#          requires:
-#            - build
-#      - unit_kernel_tests:
-#          requires:
-#            - build
-#      - dev_build:
-#          requires:
-#            - build
-#            - static_analysis
-#            - unit_kernel_tests
-      - sync_data
+      - build
+      - static_analysis:
+          requires:
+            - build
+      - unit_kernel_tests:
+          requires:
+            - build
 
+  # A nightly build of the project, using all dof-dss packages at HEAD from development branch.
   nightly-edge-build:
     triggers:
       - schedule:
@@ -360,6 +358,9 @@ workflows:
             - static_analysis
             - unit_kernel_tests
 
+  # A separate scheduled workflow to sync the data after the nightly build completes.
+  # This is separate to avoid using build time/compute units with arbitrary sleep commands;
+  # platform.sh deploy hooks can take a few minutes to execute after commits are relayed to it.
   nightly-content-sync:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ workflows:
           filters:
             branches:
               only:
-                - development
+                - D8NID-800-nightly-build
     jobs:
       - build
       - static_analysis:
@@ -369,6 +369,6 @@ workflows:
           filters:
             branches:
               only:
-                - development
+                - D8NID-edge
     jobs:
       - sync_data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
           command: |
             cd ~/project
             git checkout -b $DEV_BUILD_BRANCH
-            
+
             # Circle CI pushes direct into platform.sh repository. Any later commits via GitHub webhook
             # integration will overwrite these changes. This approach means we can decouple our
             # 'bleeding edge' package preferences here from our underlying codebase which will
@@ -304,7 +304,7 @@ jobs:
       - run:
           name: Re-sync data from master environment
           command: |
-            /home/circleci/.platformsh/bin/platform environment:activate -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH -y
+            /home/circleci/.platformsh/bin/platform sync data -p $PLATFORM_PROJECT_ID -e $DEV_BUILD_BRANCH -y
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,11 +300,10 @@ jobs:
     docker:
       - image: circleci/php:7.3.14-apache-browsers
     steps:
-      - install_php_os_extensions
       - run:
           name: Add extra OS and PHP extensions/config
           command: |
-            sudo docker-php-ext-install pcntl posix
+            sudo docker-php-ext-install gd pcntl posix
       - run:
           name: Keyscan Platform.sh region hostnames for password-less access
           command: |
@@ -323,7 +322,7 @@ workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - build
+#      - build
 #      - static_analysis:
 #          requires:
 #            - build


### PR DESCRIPTION
This PR does the following:

- Every night, Mon - Fri, it kicks off an 'edge build' that takes the development branch, swaps all dof-dss packages to use HEAD on `development` branches, then pushes the contents into a branch called  `D8NID-edge`. This is then carried over to platform.sh via the webhook integration in use at the moment where a build/deploy task is triggered. The environment is active and won't normally be pulled down until it's no longer needed, eg: site being live.
- Half an hour later, a second job runs a platform sync task on that environment to update the content from the master environment.

Circle CI doesn't push a throwaway branch to the platform.sh repo, because when I originally did this the github integration seemed to prune my branch some way through the build process and got in the way. As a result, if Circle CI pushes back to GitHub the edge branch ends up following the route of other code branches.