### PR TITLE
D8NID-785 Specify fulltext title field for contacts autocomplete search

### DIFF
--- a/config/sync/search_api_autocomplete.search.contacts.yml
+++ b/config/sync/search_api_autocomplete.search.contacts.yml
@@ -13,7 +13,8 @@ label: Contacts
 index_id: contacts
 suggester_settings:
   live_results:
-    fields: {  }
+    fields:
+      - title_fulltext
     view_modes:
       'entity:node':
         contact: ''


### PR DESCRIPTION
Should be operating with the underlying search fulltext filter criteria but in this case something's not quite feeding through correctly. This config setting corrects this for the autocomplete search and gives matching autocomplete results + search results page content on the contacts search.