### PR TITLE
Headless testing of nightwatch tests against platform.sh environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,12 +146,13 @@ jobs:
             cd /var/www/html/web/core
             ../../vendor/bin/phpunit -c /var/www/html/web/core/phpunit.circleci.xml --testsuite kernel --group nidirect
 
-  # Functional tests with headless browser; run against insolated environment.
+  # Functional tests with headless browser; run against our edge environment.
   functional_tests:
     docker:
       - image: circleci/php:7.3.14-apache-node-browsers
         environment:
-          TEST_TAGS: "search"
+          TEST_TAGS: "search origins_workflow"
+          ENVIRONMENT_ID: "d8nid-edge"
       - image: drupalci/chromedriver:production
         environment:
           CHROMEDRIVER_WHITELISTED_IPS: ""
@@ -160,7 +161,7 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: Keyscan Platform.sh region hostnames for access with our SSH keys
+          name: Keyscan Platform.sh region hostnames
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan -H ssh.$PLATFORM_REGION >> ~/.ssh/known_hosts
@@ -176,7 +177,7 @@ jobs:
             sudo apt-get install -y yarn
             sudo docker-php-ext-install pcntl posix gd
       - run:
-          name: TEMPORARY switch to dev branch of nidirect-site-modules
+          name: TEMPORARY switch to dev branch of nidirect-site-modules; remove when ready to merge!
           command: |
             cd ~/project
             composer clearcache
@@ -188,10 +189,12 @@ jobs:
       - run:
           name: Get our environment URL and store as a local shell variable
           command: |
-            echo 'export PLATFORM_ENV_URL=$(/home/circleci/.platformsh/bin/platform url -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH --pipe | sed -e "s|\/$||" | grep -e "^http://[^www]")' >> $BASH_ENV
+            # Chromedriver won't use https so we dibble around with sed/grep to find the http url we want.
+            echo 'export PLATFORM_ENV_URL=$(/home/circleci/.platformsh/bin/platform url -p $PLATFORM_PROJECT_ID -e $ENVIRONMENT_ID --pipe | sed -e "s|\/$||" | grep -e "^http://[^www]")' >> $BASH_ENV
       - run:
           name: Configure nightwatch settings and files
           command: |
+            # Create a folder to store our nightwatch reports and screenshots
             mkdir -p /home/circleci/nightwatch-reports
 
             # Copy PHPUnit config into core folder.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,7 @@ jobs:
     docker:
       - image: circleci/php:7.3.14-apache-node-browsers
         environment:
-          TEST_TAGS: "search content-type-validation origins_workflow"
-          ENVIRONMENT_ID: "d8nid-edge"
+          TEST_TAGS: "search content-type-validation origins_workflow regression"
       - image: drupalci/chromedriver:production
         environment:
           CHROMEDRIVER_WHITELISTED_IPS: ""
@@ -311,9 +310,6 @@ workflows:
       - unit_kernel_tests:
           requires:
             - build
-      - functional_tests:
-          requires:
-            - build
 
   # A nightly build of the project, using all dof-dss packages at HEAD from development branch.
   nightly-edge-build:
@@ -327,6 +323,15 @@ workflows:
                 - development
     jobs:
       - build
+      - static_analysis:
+          requires:
+            - build
+      - unit_kernel_tests:
+          requires:
+            - build
+      - functional_tests:
+          requires:
+            - build
       - edge_build:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,8 @@ jobs:
       - run:
           name: Run tests with Nightwatch.js
           command: yarn --cwd=/home/circleci/project/web/core test:nightwatch $(for tag in $TEST_TAGS; do echo --tag $tag; done)
+      - store_artifacts:
+          path: /home/circleci/nightwatch-reports
 
   # Functional tests with a JS browser; no content, only config.
   functional_js_tests__config_only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
     docker:
       - image: circleci/php:7.3.14-apache-node-browsers
         environment:
-          TEST_TAGS: "search origins_workflow"
+          TEST_TAGS: "search content-type-validation origins_workflow"
           ENVIRONMENT_ID: "d8nid-edge"
       - image: drupalci/chromedriver:production
         environment:
@@ -217,101 +217,6 @@ jobs:
           command: yarn --cwd=/home/circleci/project/web/core test:nightwatch $(for tag in $TEST_TAGS; do echo --tag $tag; done)
       - store_artifacts:
           path: /home/circleci/nightwatch-reports
-
-  # Functional tests with a JS browser; no content, only config.
-  functional_js_tests__config_only:
-    docker:
-      - image: circleci/php:7.3.14-apache-node-browsers
-      - image: circleci/mysql:5.7.27
-      - image: drupalci/chromedriver:production
-        environment:
-          CHROMEDRIVER_WHITELISTED_IPS: ""
-          CHROMEDRIVER_URL_BASE: "/wd/hub"
-    steps:
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Add extra OS and PHP extensions/config
-          command: |
-            sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
-            # Add yarn deb repo.
-            sudo apt-get update
-            sudo apt-get install -y gnupg apt-transport-https libpng-dev mariadb-client rsync
-            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-            sudo echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            sudo apt-get update
-            sudo apt-get install -y yarn
-            sudo docker-php-ext-install gd pdo_mysql
-      - run:
-          name: Copy vhost into place
-          command: |
-            sudo cp .circleci/drupal.vhost /etc/apache2/sites-available/drupal.conf
-      - run:
-          name: Transfer OS environment variables to Apache envvars file.
-          command: |
-            sudo chmod 766 /etc/apache2/envvars
-            sudo echo export DB_DRIVER=${DB_DRIVER} >> /etc/apache2/envvars
-            sudo echo export DB_HOST=${DB_HOST} >> /etc/apache2/envvars
-            sudo echo export DB_NAME=${DB_NAME} >> /etc/apache2/envvars
-            sudo echo export DB_NAMESPACE="${DB_NAMESPACE}" >> /etc/apache2/envvars
-            sudo echo export DB_PASS=${DB_PASS} >> /etc/apache2/envvars
-            sudo echo export DB_PORT=${DB_PORT} >> /etc/apache2/envvars
-            sudo echo export DB_PREFIX=${DB_PREFIX} >> /etc/apache2/envvars
-            sudo echo export DB_USER=${DB_USER} >> /etc/apache2/envvars
-            sudo echo export HASH_SALT=${HASH_SALT} >> /etc/apache2/envvars
-            sudo chmod 644 /etc/apache2/envvars
-      - run:
-          name: Enable web server and vhosts
-          command: |
-            sudo a2enmod rewrite
-            sudo a2dissite 000-default
-            sudo a2ensite drupal
-            sudo service apache2 start
-      - run:
-          name: Configure settings and files
-          command: |
-            # Should be scaffolded by now.
-            cd /home/circleci/project/web
-            cp sites/default/default.settings.php sites/default/settings.php
-            cp sites/default/default.services.yml sites/default/services.yml
-            # Copy in our environment specific settings to the settings.php file.
-            cp /home/circleci/project/.circleci/drupal.settings.php sites/default/settings.php
-            # Copy PHPUnit config into core folder.
-            cp /home/circleci/project/.circleci/phpunit.circleci.xml core/
-            # Copy Nightwatch conf files into place.
-            cat core/.env.example | sed -e "s|\(^DRUPAL_TEST_BASE_URL\)\(.\+\)|\1=http:\/\/localhost|g" > core/.env
-            sed -i -e "s|\(#\)\(DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY\)=|\2=../|g" core/.env
-            sed -i -e "s|sqlite:\/\/localhost\/sites\/default\/files/db.sqlite|mysql://root:@127.0.0.1/circle_test|g" core/.env
-            sed -i -e "s|\(^DRUPAL_TEST_WEBDRIVER_HOSTNAME\)=localhost|\1=127.0.0.1|g" core/.env
-            sed -i -e "s|^DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=true|DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false|g" core/.env
-            sed -i -e "s|\(#\)\(DRUPAL_TEST_WEBDRIVER_CHROME_ARGS\)=|\2=\"--disable-gpu --headless --no-sandbox\"|g" core/.env
-            sed -i -e "s|\(^DRUPAL_NIGHTWATCH_OUTPUT\)=reports/nightwatch|\1=/home/circleci/nightwatch-reports|g" core/.env
-            mkdir -p /home/circleci/nightwatch-reports
-            cat core/.env
-            # Install npm packages for the projects/repos we know need them.
-            cd /home/circleci/project/web/core
-            yarn install
-            cd /home/circleci/project/web/modules/custom
-            yarn install
-            cd /home/circleci/project/web/modules/migrate/nidirect-migrations/migrate_nidirect_node
-            yarn install
-      - run:
-          name: Copy files into webroot
-          command: |
-            # Copy our build into position (./ suffix ensures hidden files are copied too).
-            sudo rsync -avq /home/circleci/project/. /var/www/html
-      - run:
-          name: Install Drupal
-          command: |
-            # Install from our existing config files.
-            cd /var/www/html/web
-            ../vendor/bin/drush site-install -y --existing-config
-            ../vendor/bin/drush user:create ${TEST_USER} --mail="${TEST_USER}@example.com" --password="${TEST_PASS}"
-            ../vendor/bin/drush user:role:add "administrator" ${TEST_USER}
-          no_output_timeout: 30m
-      - run:
-          name: Run functional tests with Nightwatch.js
-          command: yarn --cwd=/var/www/html/web/core test:nightwatch ../modules/custom/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
 
   # Edge build: all dof-dss packages use HEAD on development branch, pushes to fixed non-integrating branch.
   edge_build:
@@ -400,12 +305,12 @@ workflows:
   build-test-deploy:
     jobs:
       - build
-#      - static_analysis:
-#          requires:
-#            - build
-#      - unit_kernel_tests:
-#          requires:
-#            - build
+      - static_analysis:
+          requires:
+            - build
+      - unit_kernel_tests:
+          requires:
+            - build
       - functional_tests:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,74 @@ jobs:
             cd /var/www/html/web/core
             ../../vendor/bin/phpunit -c /var/www/html/web/core/phpunit.circleci.xml --testsuite kernel --group nidirect
 
+  # Functional tests with headless browser; run against insolated environment.
+  functional_tests:
+    docker:
+      - image: circleci/php:7.3.14-apache-node-browsers
+        environment:
+          CHROMEDRIVER_WHITELISTED_IPS: ""
+          CHROMEDRIVER_URL_BASE: "/wd/hub"
+          TEST_TAGS: "search"
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Keyscan Platform.sh region hostnames for access with our SSH keys
+          command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan -H ssh.$PLATFORM_REGION >> ~/.ssh/known_hosts
+      - run:
+          name: Add extra extensions/config
+          command: |
+            sudo docker-php-ext-install pcntl posix gd
+            # Add yarn deb repo.
+            sudo apt-get update
+            sudo apt-get install -y gnupg apt-transport-https
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+            sudo echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+            sudo apt-get update
+            sudo apt-get install -y yarn
+      - run:
+          name: Install the Platform.sh CLI tool
+          command: |
+            curl -sS https://platform.sh/cli/installer | php
+      - run:
+          name: Get our environment URL and store as a local shell variable
+          command: |
+            echo 'export PLATFORM_ENV_URL=$(/home/circleci/.platformsh/bin/platform url -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH --pipe | sed -e "s|\/$||" | grep -e "http://$CIRCLE_BRANCH")' >> $BASH_ENV
+      - run:
+          name: Configure nightwatch settings and files
+          command: |
+            mkdir -p /home/circleci/nightwatch-reports
+
+            # Copy PHPUnit config into core folder.
+            cp /home/circleci/project/.circleci/phpunit.circleci.xml /home/circleci/project/web/core/
+            # Copy Nightwatch conf files into place.
+            cat /home/circleci/project/web/core/.env.example | sed -e "s|\(^DRUPAL_TEST_BASE_URL\)\(.\+\)|\1=http:\/\/$PLATFORM_ENV_URL|g" > /home/circleci/project/web/core/.env
+            sed -i -e "s|\(#\)\(DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY\)=|\2=../|g" /home/circleci/project/web/core/.env
+            sed -i -e "s|\(^DRUPAL_TEST_WEBDRIVER_HOSTNAME\)=localhost|\1=127.0.0.1|g" /home/circleci/project/web/core/.env
+            sed -i -e "s|^DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=true|DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false|g" /home/circleci/project/web/core/.env
+            sed -i -e "s|\(#\)\(DRUPAL_TEST_WEBDRIVER_CHROME_ARGS\)=|\2=\"--disable-gpu --headless --no-sandbox\"|g" /home/circleci/project/web/core/.env
+            sed -i -e "s|\(^DRUPAL_NIGHTWATCH_OUTPUT\)=reports/nightwatch|\1=/home/circleci/nightwatch-reports|g" /home/circleci/project/web/core/.env
+
+            # Install npm packages for the projects/repos we know need them.
+            for dir in core modules/custom modules/migrate/nidirect-migrations/migrate_nidirect_node; do
+              cd /home/circleci/project/web/$dir
+              yarn install
+            done
+      - run:
+          name: Create a Circle CI test user and assign role
+          command: |
+            /home/circleci/.platformsh/bin/platform environment:drush -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH "user:create $TEST_USER --mail $TEST_USER@localhost --password $TEST_PASS"
+            /home/circleci/.platformsh/bin/platform environment:drush -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH "user:role:add administrator $TEST_USER"
+      - run:
+          name: Run tests with Nightwatch.js
+          command: yarn --cwd=/home/circleci/project/web/core test:nightwatch $(for tag in ${TEST_TAGS}; do echo --tag $tag; done)
+      - run:
+          name: Remove test accounts when done
+          command: |
+            /home/circleci/.platformsh/bin/platform environment:drush -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH "user:cancel --delete-content $TEST_USER"
+
   # Functional tests with a JS browser; no content, only config.
   functional_js_tests__config_only:
     docker:
@@ -328,10 +396,13 @@ workflows:
   build-test-deploy:
     jobs:
       - build
-      - static_analysis:
-          requires:
-            - build
-      - unit_kernel_tests:
+#      - static_analysis:
+#          requires:
+#            - build
+#      - unit_kernel_tests:
+#          requires:
+#            - build
+      - functional_tests:
           requires:
             - build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,11 +150,12 @@ jobs:
   functional_tests:
     docker:
       - image: circleci/php:7.3.14-apache-node-browsers
+        environment:
+          TEST_TAGS: "search"
       - image: drupalci/chromedriver:production
         environment:
           CHROMEDRIVER_WHITELISTED_IPS: ""
           CHROMEDRIVER_URL_BASE: "/wd/hub"
-          TEST_TAGS: "search"
     steps:
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,17 +208,8 @@ jobs:
               yarn install
             done
       - run:
-          name: Create a Circle CI test user and assign role
-          command: |
-            /home/circleci/.platformsh/bin/platform environment:drush -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH "user:create $TEST_USER --mail $TEST_USER@localhost --password $TEST_PASS"
-            /home/circleci/.platformsh/bin/platform environment:drush -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH "user:role:add administrator $TEST_USER"
-      - run:
           name: Run tests with Nightwatch.js
           command: yarn --cwd=/home/circleci/project/web/core test:nightwatch $(for tag in ${TEST_TAGS}; do echo --tag $tag; done)
-      - run:
-          name: Remove test accounts when done
-          command: |
-            /home/circleci/.platformsh/bin/platform environment:drush -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH "user:cancel --delete-content $TEST_USER"
 
   # Functional tests with a JS browser; no content, only config.
   functional_js_tests__config_only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
           name: Get our environment URL and store as a local shell variable
           command: |
             # Chromedriver won't use https so we dibble around with sed/grep to find the http url we want.
-            echo 'export PLATFORM_ENV_URL=$(/home/circleci/.platformsh/bin/platform url -p $PLATFORM_PROJECT_ID -e $ENVIRONMENT_ID --pipe | sed -e "s|\/$||" | grep -e "^http://[^www]")' >> $BASH_ENV
+            echo 'export PLATFORM_ENV_URL=$(/home/circleci/.platformsh/bin/platform url -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH --pipe | sed -e "s|\/$||" | grep -e "^http://[^www]")' >> $BASH_ENV
       - run:
           name: Configure nightwatch settings and files
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,14 +165,19 @@ jobs:
       - run:
           name: Add extra extensions/config
           command: |
-            sudo docker-php-ext-install pcntl posix gd
             # Add yarn deb repo.
             sudo apt-get update
-            sudo apt-get install -y gnupg apt-transport-https
+            sudo apt-get install -y gnupg apt-transport-https libpng-dev
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             sudo echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt-get update
             sudo apt-get install -y yarn
+            sudo docker-php-ext-install pcntl posix gd
+      - run:
+          name: TEMPORARY switch to dev branch of nidirect-site-modules
+          command: |
+            cd ~/project
+            composer require dof-dss/nidirect-site-modules:dev-D8NID-809-headless-testing
       - run:
           name: Install the Platform.sh CLI tool
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
       - run:
           name: Get our environment URL and store as a local shell variable
           command: |
-            echo 'export PLATFORM_ENV_URL=$(/home/circleci/.platformsh/bin/platform url -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH --pipe | sed -e "s|\/$||" | grep -e "http://$CIRCLE_BRANCH")' >> $BASH_ENV
+            echo 'export PLATFORM_ENV_URL=$(/home/circleci/.platformsh/bin/platform url -p $PLATFORM_PROJECT_ID -e $CIRCLE_BRANCH --pipe | sed -e "s|\/$||" | grep -e "^http://[^www]")' >> $BASH_ENV
       - run:
           name: Configure nightwatch settings and files
           command: |
@@ -197,7 +197,7 @@ jobs:
             # Copy PHPUnit config into core folder.
             cp /home/circleci/project/.circleci/phpunit.circleci.xml /home/circleci/project/web/core/
             # Copy Nightwatch conf files into place.
-            cat /home/circleci/project/web/core/.env.example | sed -e "s|\(^DRUPAL_TEST_BASE_URL\)\(.\+\)|\1=http:\/\/$PLATFORM_ENV_URL|g" > /home/circleci/project/web/core/.env
+            cat /home/circleci/project/web/core/.env.example | sed -e "s|\(^DRUPAL_TEST_BASE_URL\)\(.\+\)|\1=$PLATFORM_ENV_URL|g" > /home/circleci/project/web/core/.env
             sed -i -e "s|\(#\)\(DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY\)=|\2=../|g" /home/circleci/project/web/core/.env
             sed -i -e "s|\(^DRUPAL_TEST_WEBDRIVER_HOSTNAME\)=localhost|\1=127.0.0.1|g" /home/circleci/project/web/core/.env
             sed -i -e "s|^DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=true|DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false|g" /home/circleci/project/web/core/.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,12 +176,6 @@ jobs:
             sudo apt-get install -y yarn
             sudo docker-php-ext-install pcntl posix gd
       - run:
-          name: TEMPORARY switch to dev branch of nidirect-site-modules; remove when ready to merge!
-          command: |
-            cd ~/project
-            composer clearcache
-            composer require dof-dss/nidirect-site-modules:dev-D8NID-809-headless-testing
-      - run:
           name: Install the Platform.sh CLI tool
           command: |
             curl -sS https://platform.sh/cli/installer | php

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
           name: TEMPORARY switch to dev branch of nidirect-site-modules
           command: |
             cd ~/project
+            composer clearcache
             composer require dof-dss/nidirect-site-modules:dev-D8NID-809-headless-testing
       - run:
           name: Install the Platform.sh CLI tool
@@ -210,7 +211,7 @@ jobs:
             done
       - run:
           name: Run tests with Nightwatch.js
-          command: yarn --cwd=/home/circleci/project/web/core test:nightwatch $(for tag in ${TEST_TAGS}; do echo --tag $tag; done)
+          command: yarn --cwd=/home/circleci/project/web/core test:nightwatch $(for tag in $TEST_TAGS; do echo --tag $tag; done)
 
   # Functional tests with a JS browser; no content, only config.
   functional_js_tests__config_only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,7 @@ jobs:
   functional_tests:
     docker:
       - image: circleci/php:7.3.14-apache-node-browsers
+      - image: drupalci/chromedriver:production
         environment:
           CHROMEDRIVER_WHITELISTED_IPS: ""
           CHROMEDRIVER_URL_BASE: "/wd/hub"


### PR DESCRIPTION
Sets up Circle CI so it runs our functional tests after it has built the edge environment, every workday evening.

Once the timings settle, it might be an idea to incorporate into the main pipeline especially if it runs in parallel with the long unit/kernel tests job. There shouldn't be any delay introduced, but it would consume extra CI compute/build minutes.