### PR TITLE
Shift functional tests after content refresh.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,9 +323,6 @@ workflows:
       - unit_kernel_tests:
           requires:
             - build
-      - functional_tests:
-          requires:
-            - build
       - edge_build:
           requires:
             - build
@@ -344,3 +341,6 @@ workflows:
                 - development
     jobs:
       - sync_data
+      - functional_tests:
+          requires:
+            - sync_data


### PR DESCRIPTION
Makes sense to run after latest code + content rather then just after
latest code.