### PR TITLE
Fix missing workflow dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,9 @@ workflows:
               only:
                 - development
     jobs:
+      - build
       - sync_data
       - functional_tests:
           requires:
+            - build
             - sync_data


### PR DESCRIPTION
Introduce the build step because it contains the checkout command + other files that we need for the functional tests