### PR TITLE
D8 nid 630 hc info sources

### DIFF
--- a/config/sync/core.entity_view_display.node.health_condition.full.yml
+++ b/config/sync/core.entity_view_display.node.health_condition.full.yml
@@ -21,6 +21,7 @@ dependencies:
     - field.field.node.health_condition.field_index_letter
     - field.field.node.health_condition.field_last_review_date
     - field.field.node.health_condition.field_meta_tags
+    - field.field.node.health_condition.field_next_audit_due
     - field.field.node.health_condition.field_next_review_date
     - field.field.node.health_condition.field_parent_condition
     - field.field.node.health_condition.field_photo
@@ -70,8 +71,8 @@ content:
     region: content
     label: hidden
     settings:
-      link: true
-      view_mode: default
+      view_mode: full
+      link: false
     third_party_settings: {  }
   field_last_review_date:
     type: datetime_custom
@@ -159,6 +160,7 @@ hidden:
   field_hc_secondary_symptoms: true
   field_index_letter: true
   field_meta_tags: true
+  field_next_audit_due: true
   field_parent_condition: true
   field_related_conditions: true
   field_site_themes: true

--- a/config/sync/core.entity_view_display.taxonomy_term.hc_info_sources.full.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.hc_info_sources.full.yml
@@ -1,0 +1,31 @@
+uuid: c43f6546-3d6b-48ec-9898-ac8d20c95ff4
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.full
+    - field.field.taxonomy_term.hc_info_sources.field_meta_tags
+    - taxonomy.vocabulary.hc_info_sources
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: taxonomy_term.hc_info_sources.full
+targetEntityType: taxonomy_term
+bundle: hc_info_sources
+mode: full
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_meta_tags: true
+  langcode: true
+  search_api_excerpt: true


### PR DESCRIPTION
Partial fix for https://digitaldevelopment.atlassian.net/browse/D8NID-630 where the information source for a health condition does not display correctly because the twig template expects there to be a full content display mode for the info source taxonomy term.

A separate ticket (and resulting PR) will handle the other part of this fix - see https://digitaldevelopment.atlassian.net/browse/D8NID-839

