### PR TITLE
Check out the edge branch for nightly functional testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,11 @@ jobs:
       - image: circleci/php:7.3.14-apache-browsers
     steps:
       - checkout_code
+      - run:
+          name: Checkout edge branch
+          command: |
+            cd ~/project
+            git checkout -b $EDGE_BUILD_BRANCH
       - install_php_os_extensions
       - run:
           name: Add extra OS and PHP extensions/config


### PR DESCRIPTION
So without this, the first stage of building the edge build works okay... it checks out the dev package and commits them back to the right branch. However, when the sync_data command runs it's using a build artefact from the development branch which explains why the functional tests kept not working... because they were running off tagged releases a week behind.

This step should add the extra step to check out the edge branch (already built by the earlier job) before running nightwatch tests.