### PR TITLE
D8NID-847 theme page content array adjustments

### DIFF
--- a/config/sync/core.entity_view_display.taxonomy_term.site_themes.full.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.site_themes.full.yml
@@ -1,0 +1,55 @@
+uuid: f5611ff8-b82e-47ce-b045-6ff4868a51ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.full
+    - field.field.taxonomy_term.site_themes.field_additional_info
+    - field.field.taxonomy_term.site_themes.field_banner_image
+    - field.field.taxonomy_term.site_themes.field_meta_tags
+    - field.field.taxonomy_term.site_themes.field_photo
+    - field.field.taxonomy_term.site_themes.field_supplementary_parents
+    - field.field.taxonomy_term.site_themes.field_taxonomy_rank
+    - field.field.taxonomy_term.site_themes.field_teaser
+    - field.field.taxonomy_term.site_themes.field_theme_summary
+    - field.field.taxonomy_term.site_themes.field_toc_enable
+    - field.field.taxonomy_term.site_themes.field_top_level_theme
+    - taxonomy.vocabulary.site_themes
+  module:
+    - layout_builder
+    - text
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: taxonomy_term.site_themes.full
+targetEntityType: taxonomy_term
+bundle: site_themes
+mode: full
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_theme_summary:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  field_additional_info: true
+  field_banner_image: true
+  field_meta_tags: true
+  field_photo: true
+  field_supplementary_parents: true
+  field_taxonomy_rank: true
+  field_teaser: true
+  field_toc_enable: true
+  field_top_level_theme: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.taxonomy_term.site_themes.full.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.site_themes.full.yml
@@ -34,6 +34,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_additional_info:
+    type: text_default
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_theme_summary:
     weight: 0
     label: hidden
@@ -42,7 +49,6 @@ content:
     type: text_default
     region: content
 hidden:
-  field_additional_info: true
   field_banner_image: true
   field_meta_tags: true
   field_photo: true


### PR DESCRIPTION
Ensure we can print any summary and description fields before the main info + services list.

See https://github.com/dof-dss/nicsdru_nidirect_theme/pull/147 for template.