### PR TITLE
D8NID-844 Order homepage site themes based on taxonomy weight

### DIFF
--- a/config/sync/views.view.site_themes.yml
+++ b/config/sync/views.view.site_themes.yml
@@ -493,10 +493,10 @@ display:
           entity_type: flagging
           plugin_id: flag_filter
       sorts:
-        field_taxonomy_rank_value:
-          id: field_taxonomy_rank_value
-          table: taxonomy_term__field_taxonomy_rank
-          field: field_taxonomy_rank_value
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
           relationship: none
           group_type: group
           admin_label: ''
@@ -504,6 +504,8 @@ display:
           exposed: false
           expose:
             label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
           plugin_id: standard
         name:
           id: name


### PR DESCRIPTION
Taxonomy navigator module uses the weight property, rather than a discrete field value.