### PR TITLE
D8NID-861 duplicate nodes

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -133,6 +133,7 @@ module:
   origins_shamrock_admin: 0
   origins_social_sharing: 0
   origins_toc: 0
+  origins_unique_title: 0
   origins_workflow: 0
   page_cache: 0
   path: 0


### PR DESCRIPTION
Enable the origins_unique_title module.

NB: tests will fail until the origins modules repo has a new point release, after which the module will be present allowing it to be enabled.