### PR TITLE
D8NID-687

### DIFF
--- a/config/production/fastly.settings.yml
+++ b/config/production/fastly.settings.yml
@@ -1,0 +1,1 @@
+site_id: 'master'

--- a/config/sync/config_split.config_split.production.yml
+++ b/config/sync/config_split.config_split.production.yml
@@ -6,7 +6,8 @@ id: production
 label: production
 description: 'Production site split. Locks site down to prevent config changes on the live site.'
 folder: ../config/production
-module: {  }
+module:
+  fastly: 0
 theme: {  }
 blacklist: {  }
 graylist:

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -38,7 +38,6 @@ module:
   facets: 0
   facets_pretty_paths: 0
   facets_summary: 0
-  fastly: 0
   field: 0
   field_group: 0
   field_ui: 0


### PR DESCRIPTION
Install Fastly module on production only.
Also set Fastly site id to 'master' (rather than the randomly generated id which fails validation).