### PR TITLE
Wire up geocoder API key to environment variable and hide original key in config file

### DIFF
--- a/config/sync/geocoder.settings.yml
+++ b/config/sync/geocoder.settings.yml
@@ -11,7 +11,7 @@ plugins_options:
     username: ''
     locale: ''
   googlemaps:
-    apikey: AIzaSyA7RpJuxdyv9Gp8ku57SDXeQ-wjqRUlSjI
+    apikey: ''
     locale: ''
     region: GB
     usessl: true

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -44,9 +44,11 @@ $settings['config_readonly_whitelist_patterns'] = [
   'search_api.index.default_content',
 ];
 
-// Geocoder API key.
+// Geolocation module API key.
 $config['geolocation_google_maps.settings']['google_map_api_key'] = getenv('GOOGLE_MAP_API_KEY');
 $config['geolocation_google_maps.settings']['google_map_api_server_key'] = getenv('GOOGLE_MAP_API_SERVER_KEY');
+// Geocoder module API key.
+$config['geocoder.settings']['plugins_options']['googlemaps']['apikey'] = getenv('GOOGLE_MAP_API_SERVER_KEY');
 
 // Environment indicator defaults.
 $env_colour = !empty(getenv('SIMPLEI_ENV_COLOR')) ? getenv('SIMPLEI_ENV_COLOR') : '#000000';;


### PR DESCRIPTION
Without this, geocoding of certain views based searches (eg GP practices) will silently fail as the server side geocoding error isn't reported back.