### PR TITLE
Grant term view permission for health condition symptons to anon + auth users

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -20,4 +20,5 @@ permissions:
   - 'view media'
   - 'view published gp entities'
   - 'view published sitewide alert entities'
+  - 'view terms in hc_symptoms'
   - 'view terms in site_themes'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -35,5 +35,6 @@ permissions:
   - 'view published sitewide alert entities'
   - 'view revisions'
   - 'view terms in drive_instr_categories'
+  - 'view terms in hc_symptoms'
   - 'view terms in site_themes'
   - 'view the administration theme'


### PR DESCRIPTION
Without this, anonymous users can't see symptoms in the health condition search results.