### PR TITLE
D8NID-900 migrate config sync and full import

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -72,7 +72,11 @@ hooks:
     # Rebuild caches, run db-updates and import config.
     drush -y cache-rebuild
     drush -y updatedb
-    drush -y config-import && drush -y cache-rebuild
+    # General config import
+    drush -y config-import
+    # Force partial imports of migration config.
+    ../migrate-config-sync.sh
+    drush -y cache-rebuild
 # The configuration of app when it is exposed to the web.
 web:
   # Specific parameters for different URL prefixes.

--- a/composer.lock
+++ b/composer.lock
@@ -1891,16 +1891,16 @@
         },
         {
             "name": "dof-dss/nicsdru_nidirect_theme",
-            "version": "0.11.4",
+            "version": "0.11.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dof-dss/nicsdru_nidirect_theme.git",
-                "reference": "f95060701493c2d368a8ec9b983f159f3e6c0267"
+                "reference": "d729ab5e51605a7cfab19828fa858b9d4396ea74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nicsdru_nidirect_theme/zipball/f95060701493c2d368a8ec9b983f159f3e6c0267",
-                "reference": "f95060701493c2d368a8ec9b983f159f3e6c0267",
+                "url": "https://api.github.com/repos/dof-dss/nicsdru_nidirect_theme/zipball/d729ab5e51605a7cfab19828fa858b9d4396ea74",
+                "reference": "d729ab5e51605a7cfab19828fa858b9d4396ea74",
                 "shasum": ""
             },
             "require": {
@@ -1923,7 +1923,7 @@
                 "drupal",
                 "theme"
             ],
-            "time": "2020-09-25T14:06:14+00:00"
+            "time": "2020-09-25T14:22:03+00:00"
         },
         {
             "name": "dof-dss/nicsdru_origins_modules",
@@ -4844,6 +4844,9 @@
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Add API query tweak options": "https://gist.githubusercontent.com/omahm/02ac3b7138c4d0518bd954721b74b763/raw/8d7ffa08b21359c7bf11165cdef1fb7e98483774/gac_query_options.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4865,7 +4868,8 @@
             "support": {
                 "source": "http://git.drupal.org/project/google_analytics_counter.git",
                 "issues": "https://www.drupal.org/project/issues/google_analytics_counter"
-            }
+            },
+            "time": "2020-06-17T19:33:00+00:00"
         },
         {
             "name": "drupal/handy_cache_tags",
@@ -13348,6 +13352,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Handle missing core version": "https://www.drupal.org/files/issues/2019-12-19/easy_install_core_version-3101883-0.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/migrate-config-sync.sh
+++ b/migrate-config-sync.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-DRUPAL_ROOT=/app/web
+if [ $LANDO="ON" ]; then
+  DRUPAL_ROOT=/app/drupal8/web
+else
+  DRUPAL_ROOT=/app/web
+fi
 
 echo "Refreshing database migrate config for global upgrade migrations..."
 drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_global/config/install --partial -y

--- a/migrate-config-sync.sh
+++ b/migrate-config-sync.sh
@@ -18,7 +18,7 @@ echo "Refreshing database migrate config for files..."
 drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_file/config/install --partial -y
 
 # For each, one perform a partial import task to sync the module's config with our active db config.
-for module in `$DRUSH_CMD pml | grep Enabled | grep -oE "(migrate_nidirect_node_\w+)"`; do
+for module in `drush pml | grep Enabled | grep -oE "(migrate_nidirect_node_\w+)"`; do
   echo "Refreshing database migrate config for $module..."
   drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_node/$module/config/install --partial -y
 done

--- a/migrate-config-sync.sh
+++ b/migrate-config-sync.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ $LANDO="ON" ]; then
+if [ $LANDO ]; then
   DRUPAL_ROOT=/app/drupal8/web
 else
   DRUPAL_ROOT=/app/web

--- a/migrate-config-sync.sh
+++ b/migrate-config-sync.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+DRUPAL_ROOT=/app/web
+
+echo "Refreshing database migrate config for global upgrade migrations..."
+drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_global/config/install --partial -y
+
+echo "Refreshing database migrate config for users..."
+drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_user/config/install --partial -y
+
+echo "Refreshing database migrate config for taxonomy..."
+drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_taxo/config/install --partial -y
+
+echo "Refreshing database migrate config for files..."
+drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_file/config/install --partial -y
+
+# For each, one perform a partial import task to sync the module's config with our active db config.
+for module in `$DRUSH_CMD pml | grep Enabled | grep -oE "(migrate_nidirect_node_\w+)"`; do
+  echo "Refreshing database migrate config for $module..."
+  drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_node/$module/config/install --partial -y
+done
+
+echo "Refreshing database migrate config for link..."
+drush config-import --source=$DRUPAL_ROOT/modules/migrate/nidirect-migrations/migrate_nidirect_link/config/install --partial -y

--- a/migrate-full-import.sh
+++ b/migrate-full-import.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+if [ $LANDO="ON" ]; then
+  DRUPAL_ROOT=/app/drupal8/web
+else
+  DRUPAL_ROOT=/app/web
+fi
+
+##### RESET ######
+# Reset all migrations.
+for migration_id in `drush migrate:status --format=csv | grep Importing | awk -F ',' '{print $2}'`; do
+  drush migrate:reset $migration_id
+done
+
+##### ROLLBACK ######
+
+# Rollback book migration.
+drush migrate:rollback nidirect_book
+
+# Rollback all node migrations.
+for type in driving_instructor application article external_link gp_practice health_condition landing_page news nidirect_contact contact page publication link; do
+  drush migrate:rollback --group=migrate_nidirect_node_$type
+done
+
+# Rollback GP entities.
+drush migrate:rollback --group=migrate_nidirect_entity_gp
+# Rollback media entities
+drush migrate:rollback --group=migrate_drupal_7_file
+
+##### PRE, IMPORT AND POST MIGRATE ######
+
+# Execute pre-migration commands with drupal console.
+cd $DRUPAL_ROOT
+drupal nidirect:migrate:pre
+drupal nidirect:migrate:pre:feature_nodes
+
+# Import any new users
+drush migrate:import upgrade_d7_user
+
+# Import any new taxonomy terms, with dependencies.
+drush migrate:import --group=migrate_drupal_7_taxo --execute-dependencies
+
+# Import files.
+drush migrate:import upgrade_d7_file --execute-dependencies
+# Import media entities
+drush migrate:import --group=migrate_drupal_7_file
+
+# Import GP entities.
+drush migrate:import --group=migrate_nidirect_entity_gp
+
+# Import all node migrations.
+for type in driving_instructor application article external_link gp_practice health_condition landing_page news nidirect_contact contact page publication link; do
+  drush migrate:import --group=migrate_nidirect_node_$type --execute-dependencies
+done
+
+# Import book
+drush migrate:import nidirect_book
+
+# Execute post-migration commands with drupal console.
+cd $DRUPAL_ROOT
+drupal nidirect:migrate:post
+drupal nidirect:migrate:post:feature_nodes

--- a/migrate-full-import.sh
+++ b/migrate-full-import.sh
@@ -32,7 +32,7 @@ drush migrate:rollback --group=migrate_drupal_7_link
 drush migrate:rollback nidirect_book
 
 # Rollback all node migrations.
-for type in driving_instructor application article external_link gp_practice health_condition landing_page news nidirect_contact contact page publication; do
+for type in driving_instructor application article external_link gp_practice health_condition landing_page news nidirect_contact contact page publication webform; do
   drush migrate:rollback --group=migrate_nidirect_node_$type
 done
 
@@ -63,7 +63,7 @@ drush migrate:import --group=migrate_drupal_7_file
 drush migrate:import --group=migrate_nidirect_entity_gp
 
 # Import all node migrations.
-for type in driving_instructor application article external_link gp_practice health_condition landing_page news nidirect_contact contact page publication; do
+for type in driving_instructor application article external_link gp_practice health_condition landing_page news nidirect_contact contact page publication webform; do
   drush migrate:import --group=migrate_nidirect_node_$type --execute-dependencies
 done
 
@@ -77,3 +77,7 @@ drush migrate:import --group=migrate_drupal_7_link
 cd $DRUPAL_ROOT
 drupal nidirect:migrate:post
 drupal nidirect:migrate:post:feature_nodes
+
+# Clear caches and re-index Solr.
+drush cr
+drush sapi-c && drush sapi-r && drush sapi-i


### PR DESCRIPTION
This PR aims to:

- Provide a script we can use to sync the db config from the migrate modules (excluded from the main config/sync folder due to past config import issues).
- Full rollback + re-import of content. Migrate import alone is not enough to 'top-up' the content as there are deletions to contend with. It's far safer (although time consuming) to roll it all back, re-import and re-add any extras we need on top of that.