### PR TITLE
D8 nid 915

### DIFF
--- a/config/sync/views.view.contacts_a_z.yml
+++ b/config/sync/views.view.contacts_a_z.yml
@@ -29,7 +29,7 @@ display:
       cache:
         type: custom_tag
         options:
-          custom_tag: 'node:type:{{ raw_arguments.type }}'
+          custom_tag: 'handy_cache_tags:node:contact'
       query:
         type: views_query
         options:

--- a/config/sync/views.view.health_conditions_a_to_z.yml
+++ b/config/sync/views.view.health_conditions_a_to_z.yml
@@ -31,7 +31,7 @@ display:
       cache:
         type: custom_tag
         options:
-          custom_tag: 'node:type:{{ raw_arguments.type }}'
+          custom_tag: 'handy_cache_tags:node:health_condition'
       query:
         type: views_query
         options:

--- a/config/sync/views.view.news.yml
+++ b/config/sync/views.view.news.yml
@@ -10,6 +10,7 @@ dependencies:
     - datetime
     - node
     - user
+    - views_custom_cache_tag
 id: news
 label: News
 module: views
@@ -29,8 +30,9 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: custom_tag
+        options:
+          custom_tag: 'handy_cache_tags:node:news'
       query:
         type: views_query
         options:


### PR DESCRIPTION
Had a look through all views to find those using the 'node_list' cache tag and replaced it with a 'handy cache tag' where possible (in order to greatly improve performance).
Views changed:
- Contacts A-Z
- Health conditions A-Z
- News views