### PR TITLE
Enable schema_metatag_web_page

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -151,6 +151,8 @@ module:
   schema_metatag: 0
   schema_place: 0
   schema_service: 0
+  schema_web_page: 0
+  schema_web_site: 0
   search_api: 0
   search_api_autocomplete: 0
   search_api_location: 0

--- a/config/sync/metatag.metatag_defaults.node__health_condition.yml
+++ b/config/sync/metatag.metatag_defaults.node__health_condition.yml
@@ -22,6 +22,10 @@ tags:
   twitter_cards_description: '[node:field_summary]'
   twitter_cards_type: summary
   twitter_cards_title: '[node:title]'
-  schema_medical_condition_type: MedicalCondition
-  schema_medical_condition_sign_or_symptom: '[node:field_hc_primary_symptom_1:entity:name], [node:field_hc_primary_symptom_2:entity:name], [node:field_hc_primary_symptom_3:entity:name], [node:field_hc_primary_symptom_4:entity:name]'
-  schema_medical_condition_associated_anatomy: '[node:field_hc_body_location:0:entity:name], [node:field_hc_body_location:1:entity:name], [node:field_hc_body_location:2:entity:name]'
+  schema_web_page_is_accessible_for_free: 'True'
+  schema_web_page_publisher: 'a:3:{s:5:"@type";s:22:"GovernmentOrganization";s:4:"name";s:11:"[site:name]";s:3:"url";s:10:"[site:url]";}'
+  schema_web_page_type: MedicalWebPage
+  schema_web_page_breadcrumb: 'Yes'
+  schema_web_page_description: '[node:field_summary]'
+  schema_web_page_id: '[current-page:url:unaliased]'
+  schema_web_page_author: 'a:4:{s:5:"@type";s:22:"GovernmentOrganization";s:4:"name";s:11:"[site:name]";s:3:"url";s:10:"[site:url]";s:4:"logo";a:2:{s:5:"@type";s:11:"ImageObject";s:3:"url";s:55:"[site:url]themes/custom/nicsdru_nidirect_theme/logo.svg";}}'

--- a/config/sync/metatag.settings.yml
+++ b/config/sync/metatag.settings.yml
@@ -34,6 +34,7 @@ entity_type_groups:
       open_graph: open_graph
       facebook: facebook
       twitter_cards: twitter_cards
+      schema_web_page: schema_web_page
     landing_page:
       basic: basic
       advanced: advanced


### PR DESCRIPTION
Allows Health Condition nodes to extend and define MedicalPage schema elements, augmented with preprocessing in nidirect_health_conditions.module