### PR TITLE
D8NID-870 LinkIt substitution plugin output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/layout_builder_modal": "^1.0@alpha",
         "drupal/layout_builder_restrictions": "^2.2",
-        "drupal/linkit": "^5.0",
+        "drupal/linkit": "^6.0.0",
         "drupal/media_library_edit": "^1.0@alpha",
         "drupal/metatag": "^1.8",
         "drupal/migrate_upgrade": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -182,6 +182,9 @@
             },
             "drupal/schema_metatag": {
                 "Add @id as a tag to all schemas": "https://www.drupal.org/files/issues/2019-09-01/3078582-02.patch"
+            },
+            "drupal/linkit": {
+                "Link shown after the autocomplete selection is the bare node/xxx link, not the alias": "https://www.drupal.org/files/issues/2020-11-03/show_alias_in_autocomplete_selection-2877535-16.patch"
             }
         },
         "composer-exit-on-patch-failure": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc5e52b83ac0b208999c5948fd18009c",
+    "content-hash": "8aa653978f4f37bb6eb4d57d5e9f72ad",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5303,6 +5303,9 @@
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Link shown after the autocomplete selection is the bare node/xxx link, not the alias": "https://www.drupal.org/files/issues/2020-11-03/show_alias_in_autocomplete_selection-2877535-16.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9a54d910603478f26705763b668ed5e",
+    "content-hash": "3de8e808a8ff2d5a1384dc3b9ebf949e",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5275,17 +5275,17 @@
         },
         {
             "name": "drupal/linkit",
-            "version": "5.0.0-beta11",
+            "version": "6.0.0-beta1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/linkit.git",
-                "reference": "8.x-5.0-beta11"
+                "reference": "6.0.0-beta1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/linkit-8.x-5.0-beta11.zip",
-                "reference": "8.x-5.0-beta11",
-                "shasum": "9133a3e61deafdd6a9d5a8b31a1f42e16051ee97"
+                "url": "https://ftp.drupal.org/files/projects/linkit-6.0.0-beta1.zip",
+                "reference": "6.0.0-beta1",
+                "shasum": "1842f07ccacbf1d697b66b2503217eeb5dc0f813"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9"
@@ -5296,8 +5296,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-5.0-beta11",
-                    "datestamp": "1591971693",
+                    "version": "6.0.0-beta1",
+                    "datestamp": "1591971462",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."


### PR DESCRIPTION
Replaces the canonical path (node/123) with the aliased title for better UX. Underlying markup uses a content UUID to help avoid losing track of the link in case the alias changes, eg:

```
<a data-entity-substitution="canonical" data-entity-type="taxonomy_term" data-entity-uuid="bd9bb3f3-e3a3-42e1-ae2d-8de8f52b054e" href="/information-and-services/people-disabilities/motoring-and-transport">some link text</a>
```

and

```
<a data-entity-substitution="canonical" data-entity-type="node" data-entity-uuid="5920e0e0-5654-4321-af07-2d126b1a19cc" href="/articles/fixed-penalties-motoring-offences">some link text</a>
```