### PR TITLE
Sort contact_children view by 'sticky at top of lists' 

### DIFF
--- a/config/sync/views.view.contact_children.yml
+++ b/config/sync/views.view.contact_children.yml
@@ -146,6 +146,20 @@ display:
             operator_limit_selection: false
             operator_list: {  }
       sorts:
+        sticky:
+          id: sticky
+          table: node_field_revision
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: standard
         title:
           id: title
           table: node_field_data


### PR DESCRIPTION
Enable editors to promote contacts to the top of contact_children views - e.g. on a contact page for gov departments, The Executive Office would be promoted to the top followed by the rest of departments in alphabetical order.

See also https://github.com/dof-dss/nidirect-site-modules/pull/280