### PR TITLE
Adds patch for telephone_plus 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -186,6 +186,9 @@
             },
             "drupal/linkit": {
                 "Link shown after the autocomplete selection is the bare node/xxx link, not the alias": "https://www.drupal.org/files/issues/2020-11-03/show_alias_in_autocomplete_selection-2877535-16.patch"
+            },
+            "drupal/telephone_plus": {
+                "Add telephone extension into the link text": "https://www.drupal.org/files/issues/2020-12-03/3186246-1.patch"
             }
         },
         "composer-exit-on-patch-failure": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eaa68f154fdbd4c792053764a3eee8c4",
+    "content-hash": "e5f2c3788a0e07e853eac0b20debcb0f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -6939,6 +6939,9 @@
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
                     }
+                },
+                "patches_applied": {
+                    "Add telephone extension into the link text": "https://www.drupal.org/files/issues/2020-12-03/3186246-1.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",


### PR DESCRIPTION
Patch adds phone extension into link text of phone links.

https://www.drupal.org/project/telephone_plus/issues/3186246

https://www.drupal.org/files/issues/2020-12-03/3186246-1.patch