### PR TITLE
D8NID-872 node edit protection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "drupal/migrate_absolute_links": "1.x-dev",
         "drupal/migrate_upgrade": "^3.2",
         "drupal/moderation_sidebar": "^1.3",
+        "drupal/node_edit_protection": "^1.0",
         "drupal/noreferrer": "^1.7",
         "drupal/paragraphs": "^1.8",
         "drupal/pathauto": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74cdf30a266d288a9ee8a4ee829bb2c2",
+    "content-hash": "599bc6ab37a92dd1bedc71de39f09a8e",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5763,6 +5763,66 @@
             "homepage": "https://www.drupal.org/project/moderation_sidebar",
             "support": {
                 "source": "https://git.drupalcode.org/project/moderation_sidebar"
+            }
+        },
+        {
+            "name": "drupal/node_edit_protection",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/node_edit_protection.git",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/node_edit_protection-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "741f873893607b3d7f729afa1447af0a5f2c1fd8"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1598972381",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mohammed J. Razem",
+                    "homepage": "https://www.drupal.org/user/255384"
+                },
+                {
+                    "name": "czigor",
+                    "homepage": "https://www.drupal.org/user/826222"
+                },
+                {
+                    "name": "erynn",
+                    "homepage": "https://www.drupal.org/user/1163382"
+                },
+                {
+                    "name": "febbraro",
+                    "homepage": "https://www.drupal.org/user/43670"
+                },
+                {
+                    "name": "mgifford",
+                    "homepage": "https://www.drupal.org/user/27930"
+                }
+            ],
+            "description": "Protect the user against navigating away from a node edit form before saving their changes.",
+            "homepage": "https://www.drupal.org/project/node_edit_protection",
+            "support": {
+                "source": "https://git.drupalcode.org/project/node_edit_protection"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -126,6 +126,7 @@ module:
   nidirect_tour: 0
   nidirect_webforms: 0
   node: 0
+  node_edit_protection: 0
   noreferrer: 0
   options: 0
   origins_ckeditor_enhancements: 0


### PR DESCRIPTION
Used on the legacy site. The 8.x version of the [node_edit_protection](https://git.drupalcode.org/project/node_edit_protection) contrib module seems to be put together well enough to not warrant a purely custom code approach.