### PR TITLE
Allow unpublished content to be referenced

### DIFF
--- a/config/sync/field.field.node.health_condition.field_alternative_condition.yml
+++ b/config/sync/field.field.node.health_condition.field_alternative_condition.yml
@@ -17,12 +17,12 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: unpublished
   handler_settings:
     target_bundles:
       health_condition_alternative: health_condition_alternative
     sort:
       field: _none
-    auto_create: true
+    auto_create: 1
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/sync/field.field.node.health_condition.field_parent_condition.yml
+++ b/config/sync/field.field.node.health_condition.field_parent_condition.yml
@@ -16,14 +16,12 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: unpublished
   handler_settings:
-    behaviors:
-      views-select-list:
-        status: 0
-    sort:
-      field: _none
-      direction: ASC
     target_bundles:
       health_condition: health_condition
+    sort:
+      field: _none
+    auto_create: 0
+    auto_create_bundle: ''
 field_type: entity_reference


### PR DESCRIPTION
Ensures that as HC nodes move between moderation states, the HCA nodes are kept in sync for all user roles without triggering deeper moderation or widget validation errors.