### PR TITLE
Set cardinality on attachment field to be unlimited

### DIFF
--- a/config/sync/field.storage.node.field_attachment.yml
+++ b/config/sync/field.storage.node.field_attachment.yml
@@ -13,7 +13,7 @@ settings:
   target_type: media
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
D8NID-1040: allows publications to reference more than a single document media entity.