### PR TITLE
Temporarily peg nicsdru_nidirect_theme to specific master commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.5",
-        "dof-dss/nicsdru_nidirect_theme": "dev-master#11d4063fd576b1bb437183f650f85f4f71ec56ef",
+        "dof-dss/nicsdru_nidirect_theme": "dev-master",
         "dof-dss/nicsdru_origins_modules": "^0.9.10",
         "dof-dss/nicsdru_origins_theme": "^0.3.3",
         "dof-dss/nidirect-d8-test-install-profile": "^0.2.2",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.5",
-        "dof-dss/nicsdru_nidirect_theme": "^0.11.15",
+        "dof-dss/nicsdru_nidirect_theme": "dev-master#11d4063fd576b1bb437183f650f85f4f71ec56ef",
         "dof-dss/nicsdru_origins_modules": "^0.9.10",
         "dof-dss/nicsdru_origins_theme": "^0.3.3",
         "dof-dss/nidirect-d8-test-install-profile": "^0.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "830a7c87a9a4b72a9358b6440f66915d",
+    "content-hash": "d23105e5ea17d8483c7591e544e2d458",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1934,16 +1934,16 @@
         },
         {
             "name": "dof-dss/nicsdru_nidirect_theme",
-            "version": "0.11.15",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dof-dss/nicsdru_nidirect_theme.git",
-                "reference": "bb10a7fd6e9a2344878b9374b25b2b830a7ace3f"
+                "reference": "11d4063fd576b1bb437183f650f85f4f71ec56ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nicsdru_nidirect_theme/zipball/bb10a7fd6e9a2344878b9374b25b2b830a7ace3f",
-                "reference": "bb10a7fd6e9a2344878b9374b25b2b830a7ace3f",
+                "url": "https://api.github.com/repos/dof-dss/nicsdru_nidirect_theme/zipball/11d4063fd576b1bb437183f650f85f4f71ec56ef",
+                "reference": "11d4063fd576b1bb437183f650f85f4f71ec56ef",
                 "shasum": ""
             },
             "require": {
@@ -1966,7 +1966,7 @@
                 "drupal",
                 "theme"
             ],
-            "time": "2021-01-13T13:24:09+00:00"
+            "time": "2021-01-15T10:38:59+00:00"
         },
         {
             "name": "dof-dss/nicsdru_origins_modules",
@@ -17368,6 +17368,7 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "dof-dss/nicsdru_nidirect_theme": 20,
         "drupal/config_readonly": 10,
         "drupal/facets_pretty_paths": 10,
         "drupal/flag": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d23105e5ea17d8483c7591e544e2d458",
+    "content-hash": "172d428ef54ecec53f30dc630a8fb2ef",
     "packages": [
         {
             "name": "alchemy/zippy",


### PR DESCRIPTION
Avoids interrupting the tagging numbering. It should have been possible to re-tag and do the mess-around with tag numbers, but it's just as easy to reference a specific commit in the master branch as a temporary stopgap.