### PR TITLE
Update whatlinkshere module to 1.6 to fix inefficient drupal console commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
         "drupal/views_custom_cache_tag": "^1.1",
         "drupal/views_data_export": "^1.0",
         "drupal/webform": "^5.23-beta1",
-        "drupal/whatlinkshere": "^1.5",
+        "drupal/whatlinkshere": "^1.6",
         "drupal/xls_serialization": "^1.2",
         "drush/drush": "^10.1",
         "harvesthq/chosen": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "172d428ef54ecec53f30dc630a8fb2ef",
+    "content-hash": "89c649212ae0902b96aebce1eb2a881a",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -409,16 +409,6 @@
                 "yawik",
                 "zend",
                 "zikula"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-04-07T06:57:05+00:00"
         },
@@ -6680,7 +6670,7 @@
             "extra": {
                 "drupal": {
                     "version": "4.1.7",
-                    "datestamp": "1604326374",
+                    "datestamp": "1603086036",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7816,29 +7806,34 @@
         },
         {
             "name": "drupal/whatlinkshere",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/whatlinkshere.git",
-                "reference": "8.x-1.5"
+                "reference": "8.x-1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/whatlinkshere-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "02214e42473381e6a61f1449c93136910668274e"
+                "url": "https://ftp.drupal.org/files/projects/whatlinkshere-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "bfb2406ed912deb8d905239fce32a380ec38bfdd"
             },
             "require": {
-                "drupal/core": "~8.0"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1589375324",
+                    "version": "8.x-1.6",
+                    "datestamp": "1610969911",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^10"
                     }
                 }
             },
@@ -11677,20 +11672,6 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-31T05:53:42+00:00"
         },
         {
@@ -12988,16 +12969,6 @@
                 "dotenv",
                 "env",
                 "environment"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-02T13:38:00+00:00"
         },
@@ -17349,12 +17320,6 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "funding": [
-                {
-                    "url": "https://github.com/theseer",
-                    "type": "github"
-                }
-            ],
             "time": "2020-07-12T23:59:07+00:00"
         }
     ],


### PR DESCRIPTION
Cut a specific release for 8.8.x versions as Core 8.9.x/9.x changes the namespace for the alias manager service which the link manager service depends on.