### PR TITLE
Move social sharing block

### DIFF
--- a/config/sync/block.block.healthconditionsfacetsummary.yml
+++ b/config/sync/block.block.healthconditionsfacetsummary.yml
@@ -12,7 +12,7 @@ dependencies:
 id: healthconditionsfacetsummary
 theme: nicsdru_nidirect_theme
 region: content
-weight: -16
+weight: -14
 provider: null
 plugin: 'facets_summary_block:health_conditions_facet_summary'
 settings:

--- a/config/sync/block.block.mainpagecontent.yml
+++ b/config/sync/block.block.mainpagecontent.yml
@@ -9,7 +9,7 @@ dependencies:
 id: mainpagecontent
 theme: nicsdru_nidirect_theme
 region: content
-weight: -15
+weight: -16
 provider: null
 plugin: system_main_block
 settings:

--- a/config/sync/block.block.originssocialsharing.yml
+++ b/config/sync/block.block.originssocialsharing.yml
@@ -1,16 +1,17 @@
 uuid: 08f8a718-7336-43d2-9733-5a63521c514c
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - node
     - origins_social_sharing
+    - system
   theme:
     - nicsdru_nidirect_theme
 id: originssocialsharing
 theme: nicsdru_nidirect_theme
-region: bottom_banner
-weight: -18
+region: content
+weight: -13
 provider: null
 plugin: origins_social_sharing
 settings:
@@ -26,12 +27,18 @@ visibility:
       article: article
       contact: contact
       embargoed_publication: embargoed_publication
+      gp_practice: gp_practice
       health_condition: health_condition
       landing_page: landing_page
       news: news
       publication: publication
-      recipe: recipe
-      umbrella_body: umbrella_body
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+  request_path:
+    id: request_path
+    pages: |
+      <front>
+      /information-and-services/*
+    negate: true
+    context_mapping: {  }

--- a/config/sync/block.block.views_block__site_themes_site_themes_home_page.yml
+++ b/config/sync/block.block.views_block__site_themes_site_themes_home_page.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__site_themes_site_themes_home_page
 theme: nicsdru_nidirect_theme
 region: content
-weight: -14
+weight: -15
 provider: null
 plugin: 'views_block:site_themes-site_themes_home_page'
 settings:


### PR DESCRIPTION
- move back into the content region (better DOM position for accessibility) and disable it (will be output via drupal_block() call in twig - see https://github.com/dof-dss/nicsdru_nidirect_theme/pull/224)
- enable block on GP practices