### PR TITLE
Enable the GAC cron task

### DIFF
--- a/config/sync/ultimate_cron.job.google_analytics_counter_cron.yml
+++ b/config/sync/ultimate_cron.job.google_analytics_counter_cron.yml
@@ -1,6 +1,6 @@
 uuid: 1e901f4c-6347-4776-8c2d-1aebba672ac6
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - google_analytics_counter


### PR DESCRIPTION
Ensures that the most popular blocks are routinely updated