### PR TITLE
A11y fixes

### DIFF
--- a/config/sync/responsive_image.styles.article_full.yml
+++ b/config/sync/responsive_image.styles.article_full.yml
@@ -4,33 +4,26 @@ status: true
 dependencies:
   config:
     - image.style.nigov_full_1240_x2
+    - image.style.nigov_full_1880_x2
     - image.style.nigov_full_450_x1
     - image.style.nigov_full_620_x1
     - image.style.nigov_full_900_x2
-  theme:
-    - nicsdru_origins_theme
+    - image.style.nigov_full_940_x1
 id: article_full
 label: 'Article full'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_620_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_1240_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_450_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_900_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_full_1240_x2
+        - nigov_full_1880_x2
+        - nigov_full_450_x1
+        - nigov_full_620_x1
+        - nigov_full_900_x2
+        - nigov_full_940_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_full_620_x1

--- a/config/sync/responsive_image.styles.card_large.yml
+++ b/config/sync/responsive_image.styles.card_large.yml
@@ -5,20 +5,17 @@ dependencies:
   config:
     - image.style.nigov_card_large_460x140_x1
     - image.style.nigov_card_large_920x280_x2
-  theme:
-    - nicsdru_origins_theme
 id: card_large
 label: 'Card large'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.min
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_card_large_460x140_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_card_large_920x280_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_card_large_460x140_x1
+        - nigov_card_large_920x280_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_card_large_460x140_x1

--- a/config/sync/responsive_image.styles.card_small.yml
+++ b/config/sync/responsive_image.styles.card_small.yml
@@ -5,20 +5,17 @@ dependencies:
   config:
     - image.style.nigov_card_small_305x150_x1
     - image.style.nigov_card_small_610x300_x2
-  theme:
-    - nicsdru_origins_theme
 id: card_small
 label: 'Card small'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.min
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_card_small_305x150_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_card_small_610x300_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_card_small_305x150_x1
+        - nigov_card_small_610x300_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_card_small_305x150_x1

--- a/config/sync/responsive_image.styles.card_thumbnail.yml
+++ b/config/sync/responsive_image.styles.card_thumbnail.yml
@@ -5,20 +5,17 @@ dependencies:
   config:
     - image.style.nigov_landscape_thumbnail_150x100_x1
     - image.style.nigov_landscape_thumbnail_300x200_x2
-  theme:
-    - nicsdru_origins_theme
 id: card_thumbnail
 label: 'Card thumbnail'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.min
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_thumbnail_150x100_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_thumbnail_300x200_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_landscape_thumbnail_150x100_x1
+        - nigov_landscape_thumbnail_300x200_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_landscape_thumbnail_150x100_x1

--- a/config/sync/responsive_image.styles.deep_banner.yml
+++ b/config/sync/responsive_image.styles.deep_banner.yml
@@ -5,30 +5,17 @@ dependencies:
   config:
     - image.style.nigov_banner_1880x600_x2
     - image.style.nigov_banner_940x300_x1
-  theme:
-    - nicsdru_origins_theme
 id: deep_banner
 label: 'Banner deep'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_940x300_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_1880x600_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_940x300_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_940x300_x1
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_banner_1880x600_x2
+        - nigov_banner_940x300_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_banner_940x300_x1

--- a/config/sync/responsive_image.styles.feature_card.yml
+++ b/config/sync/responsive_image.styles.feature_card.yml
@@ -5,20 +5,17 @@ dependencies:
   config:
     - image.style.nigov_card_small_300x150_x1
     - image.style.nigov_card_small_600x300_x2
-  theme:
-    - nicsdru_origins_theme
 id: feature_card
 label: 'Feature card'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.min
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_card_small_300x150_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_card_small_600x300_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_card_small_300x150_x1
+        - nigov_card_small_600x300_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_card_small_300x150_x1

--- a/config/sync/responsive_image.styles.inline.yml
+++ b/config/sync/responsive_image.styles.inline.yml
@@ -3,34 +3,35 @@ langcode: en
 status: true
 dependencies:
   config:
+    - image.style.nigov_landscape_1240x826_x2
     - image.style.nigov_landscape_300x200_x1
     - image.style.nigov_landscape_450x300_x1
     - image.style.nigov_landscape_600x400_x2
+    - image.style.nigov_landscape_620x413_x1
     - image.style.nigov_landscape_900x600_x2
-  theme:
-    - nicsdru_origins_theme
+    - image.style.nigov_landscape_thumbnail_150x100_x1
+    - image.style.nigov_landscape_thumbnail_300x200_x2
+    - image.style.nigov_landscape_xxl_1920x1280_x2
+    - image.style.nigov_landscape_xxl_960x640_x1
 id: inline
 label: 'Landscape float'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_300x200_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_600x400_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_450x300_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_900x600_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_landscape_1240x826_x2
+        - nigov_landscape_300x200_x1
+        - nigov_landscape_450x300_x1
+        - nigov_landscape_600x400_x2
+        - nigov_landscape_620x413_x1
+        - nigov_landscape_900x600_x2
+        - nigov_landscape_thumbnail_150x100_x1
+        - nigov_landscape_thumbnail_300x200_x2
+        - nigov_landscape_xxl_1920x1280_x2
+        - nigov_landscape_xxl_960x640_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_landscape_300x200_x1

--- a/config/sync/responsive_image.styles.inline_expandable.yml
+++ b/config/sync/responsive_image.styles.inline_expandable.yml
@@ -7,30 +7,19 @@ dependencies:
     - image.style.nigov_landscape_450x300_x1
     - image.style.nigov_landscape_620x413_x1
     - image.style.nigov_landscape_900x600_x2
-  theme:
-    - nicsdru_origins_theme
 id: inline_expandable
 label: 'Landscape float expandable'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_620x413_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_1240x826_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_450x300_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_900x600_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_landscape_1240x826_x2
+        - nigov_landscape_450x300_x1
+        - nigov_landscape_620x413_x1
+        - nigov_landscape_900x600_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_landscape_620x413_x1

--- a/config/sync/responsive_image.styles.inline_xl.yml
+++ b/config/sync/responsive_image.styles.inline_xl.yml
@@ -7,30 +7,19 @@ dependencies:
     - image.style.nigov_landscape_450x300_x1
     - image.style.nigov_landscape_620x413_x1
     - image.style.nigov_landscape_900x600_x2
-  theme:
-    - nicsdru_origins_theme
 id: inline_xl
 label: 'Landscape full width'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_620x413_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_1240x826_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_450x300_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_900x600_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_landscape_1240x826_x2
+        - nigov_landscape_450x300_x1
+        - nigov_landscape_620x413_x1
+        - nigov_landscape_900x600_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_landscape_620x413_x1

--- a/config/sync/responsive_image.styles.inline_xl_expandable.yml
+++ b/config/sync/responsive_image.styles.inline_xl_expandable.yml
@@ -9,40 +9,21 @@ dependencies:
     - image.style.nigov_landscape_900x600_x2
     - image.style.nigov_landscape_xxl_1920x1280_x2
     - image.style.nigov_landscape_xxl_960x640_x1
-  theme:
-    - nicsdru_origins_theme
 id: inline_xl_expandable
 label: 'Landscape full width expandable'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.phab
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_xxl_960x640_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.phab
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_xxl_1920x1280_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_620x413_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_1240x826_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_450x300_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_900x600_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_landscape_1240x826_x2
+        - nigov_landscape_450x300_x1
+        - nigov_landscape_620x413_x1
+        - nigov_landscape_900x600_x2
+        - nigov_landscape_xxl_1920x1280_x2
+        - nigov_landscape_xxl_960x640_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_landscape_xxl_960x640_x1

--- a/config/sync/responsive_image.styles.landing_full.yml
+++ b/config/sync/responsive_image.styles.landing_full.yml
@@ -9,40 +9,21 @@ dependencies:
     - image.style.nigov_full_620_x1
     - image.style.nigov_full_900_x2
     - image.style.nigov_full_940_x1
-  theme:
-    - nicsdru_origins_theme
 id: landing_full
 label: 'Landing full'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.phab
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_940_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.phab
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_1880_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_620_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_1240_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_450_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_full_900_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_full_1240_x2
+        - nigov_full_1880_x2
+        - nigov_full_450_x1
+        - nigov_full_620_x1
+        - nigov_full_900_x2
+        - nigov_full_940_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_full_940_x1

--- a/config/sync/responsive_image.styles.news_thumbnail.yml
+++ b/config/sync/responsive_image.styles.news_thumbnail.yml
@@ -5,20 +5,17 @@ dependencies:
   config:
     - image.style.nigov_landscape_thumbnail_150x100_x1
     - image.style.nigov_landscape_thumbnail_300x200_x2
-  theme:
-    - nicsdru_origins_theme
 id: news_thumbnail
 label: 'News thumbnail'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.min
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_thumbnail_150x100_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_landscape_thumbnail_300x200_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_landscape_thumbnail_150x100_x1
+        - nigov_landscape_thumbnail_300x200_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_landscape_thumbnail_150x100_x1

--- a/config/sync/responsive_image.styles.portrait_float.yml
+++ b/config/sync/responsive_image.styles.portrait_float.yml
@@ -7,30 +7,19 @@ dependencies:
     - image.style.nigov_portrait_600_x2
     - image.style.nigov_portrait_med_450_x1
     - image.style.nigov_portrait_med_900_x2
-  theme:
-    - nicsdru_origins_theme
 id: portrait_float
 label: 'Portrait float'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_300_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_600_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_med_450_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_med_900_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_portrait_300_x1
+        - nigov_portrait_600_x2
+        - nigov_portrait_med_450_x1
+        - nigov_portrait_med_900_x2
+breakpoint_group: responsive_image
 fallback_image_style: nigov_portrait_300_x1

--- a/config/sync/responsive_image.styles.portrait_float_expandable.yml
+++ b/config/sync/responsive_image.styles.portrait_float_expandable.yml
@@ -7,30 +7,19 @@ dependencies:
     - image.style.nigov_portrait_med_900_x2
     - image.style.nigov_portrait_xl_1240_x2
     - image.style.nigov_portrait_xl_620_x1
-  theme:
-    - nicsdru_origins_theme
 id: portrait_float_expandable
 label: 'Portrait float expandable'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_xl_620_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_xl_1240_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_med_450_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_med_900_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_portrait_med_450_x1
+        - nigov_portrait_med_900_x2
+        - nigov_portrait_xl_1240_x2
+        - nigov_portrait_xl_620_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_portrait_xl_620_x1

--- a/config/sync/responsive_image.styles.portrait_full_width.yml
+++ b/config/sync/responsive_image.styles.portrait_full_width.yml
@@ -7,30 +7,19 @@ dependencies:
     - image.style.nigov_portrait_med_900_x2
     - image.style.nigov_portrait_xl_1240_x2
     - image.style.nigov_portrait_xl_620_x1
-  theme:
-    - nicsdru_origins_theme
 id: portrait_full_width
 label: 'Portrait full width'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_xl_620_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_xl_1240_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_med_450_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_portrait_med_900_x2
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_portrait_med_450_x1
+        - nigov_portrait_med_900_x2
+        - nigov_portrait_xl_1240_x2
+        - nigov_portrait_xl_620_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_portrait_xl_620_x1

--- a/config/sync/responsive_image.styles.thin_banner.yml
+++ b/config/sync/responsive_image.styles.thin_banner.yml
@@ -5,30 +5,17 @@ dependencies:
   config:
     - image.style.nigov_banner_1880x200_x2
     - image.style.nigov_banner_940x100_x1
-  theme:
-    - nicsdru_origins_theme
 id: thin_banner
 label: 'Banner thin'
 image_style_mappings:
   -
-    breakpoint_id: nicsdru_origins_theme.mob
+    breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_940x100_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.mob
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_1880x200_x2
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 1x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_940x100_x1
-  -
-    breakpoint_id: nicsdru_origins_theme.min
-    multiplier: 2x
-    image_mapping_type: image_style
-    image_mapping: nigov_banner_940x100_x1
-breakpoint_group: nicsdru_origins_theme
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: 100vw
+      sizes_image_styles:
+        - nigov_banner_1880x200_x2
+        - nigov_banner_940x100_x1
+breakpoint_group: responsive_image
 fallback_image_style: nigov_banner_940x100_x1


### PR DESCRIPTION
Convert responsive image styles to use img srcset method for delivering various image sizes.  

The picture method we had been using was cumbersome and probably unnecessary since we just need to deliver the same image in various sizes (see https://css-tricks.com/responsive-images-youre-just-changing-resolutions-use-srcset/).  

Another reason is that Drupal / Twig was not outputting valid html for the picture element and its child source elements.  `<source>` elements are void elements (no closing tag) - but for some reason Drupal adds the closing tag even though its in the twig as `<source />`.  Rather than fight this weirdness I decided to make the leap to the srcset method instead.

Related: 
- https://github.com/dof-dss/nicsdru_nidirect_theme/pull/228
- https://github.com/dof-dss/nicsdru_origins_theme/pull/78