### PR TITLE
Updates composer.lock with updated version of nidirect theme

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1941,16 +1941,16 @@
         },
         {
             "name": "dof-dss/nicsdru_nidirect_theme",
-            "version": "0.11.18",
+            "version": "0.11.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dof-dss/nicsdru_nidirect_theme.git",
-                "reference": "98aa8f27d8144e7576a86656e63a60008a6784b8"
+                "reference": "2bffe38f1a706334fd67c4d962d708c40e41db64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nicsdru_nidirect_theme/zipball/98aa8f27d8144e7576a86656e63a60008a6784b8",
-                "reference": "98aa8f27d8144e7576a86656e63a60008a6784b8",
+                "url": "https://api.github.com/repos/dof-dss/nicsdru_nidirect_theme/zipball/2bffe38f1a706334fd67c4d962d708c40e41db64",
+                "reference": "2bffe38f1a706334fd67c4d962d708c40e41db64",
                 "shasum": ""
             },
             "require": {
@@ -1973,7 +1973,7 @@
                 "drupal",
                 "theme"
             ],
-            "time": "2021-01-27T17:41:25+00:00"
+            "time": "2021-01-28T14:00:54+00:00"
         },
         {
             "name": "dof-dss/nicsdru_origins_modules",


### PR DESCRIPTION
Updates the nidirect theme to the latest version.  I noticed a small gaff in yesterdays release affecting the images in all cards (like the features on the homepage).  The images have margins ruining the look of the card.  Not a huge deal - but annoying.