### PR TITLE
Convert media reference field to private file field

### DIFF
--- a/config/sync/core.entity_form_display.node.embargoed_publication.default.yml
+++ b/config/sync/core.entity_form_display.node.embargoed_publication.default.yml
@@ -17,8 +17,7 @@ dependencies:
   module:
     - content_moderation
     - datetime
-    - media_library
-    - media_library_edit
+    - file
     - metatag
     - path
     - scheduler
@@ -66,14 +65,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_secure_attachment:
-    type: media_library_widget
     weight: 9
-    region: content
     settings:
-      media_types: {  }
-    third_party_settings:
-      media_library_edit:
-        show_edit: '1'
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
   field_site_themes:
     type: options_shs
     weight: 4

--- a/config/sync/core.entity_view_display.node.embargoed_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - node.type.embargoed_publication
   module:
     - datetime
+    - file
     - metatag
     - options
     - smart_trim
@@ -56,13 +57,12 @@ content:
       timezone_override: ''
     third_party_settings: {  }
   field_secure_attachment:
-    type: entity_reference_entity_view
     weight: 9
     label: above
     settings:
-      view_mode: default
-      link: false
+      use_description_as_link_text: true
     third_party_settings: {  }
+    type: file_default
     region: content
   field_site_themes:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.embargoed_publication.diff.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.diff.yml
@@ -88,15 +88,6 @@ content:
       format_type: medium
       timezone_override: ''
     third_party_settings: {  }
-  field_secure_attachment:
-    type: entity_reference_entity_view
-    weight: 4
-    label: inline
-    settings:
-      view_mode: default
-      link: false
-    third_party_settings: {  }
-    region: content
   field_site_themes:
     type: entity_reference_label
     weight: 8
@@ -126,6 +117,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_secure_attachment: true
   field_top_level_theme: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.embargoed_publication.full.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.full.yml
@@ -16,6 +16,7 @@ dependencies:
     - node.type.embargoed_publication
   module:
     - datetime
+    - file
     - layout_builder
     - smart_trim
     - text
@@ -46,14 +47,13 @@ content:
       format_type: medium_date
     third_party_settings: {  }
   field_secure_attachment:
-    type: entity_reference_entity_view
+    type: file_default
     weight: 3
-    label: inline
-    settings:
-      view_mode: embed
-      link: false
-    third_party_settings: {  }
     region: content
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
   field_summary:
     weight: 1
     label: hidden

--- a/config/sync/field.field.node.embargoed_publication.field_secure_attachment.yml
+++ b/config/sync/field.field.node.embargoed_publication.field_secure_attachment.yml
@@ -1,35 +1,33 @@
-uuid: 5c974d0f-f367-443e-96fe-572f0f8e6c67
+uuid: ccd6f7f6-6117-485d-af0e-9cce150856ba
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_secure_attachment
-    - media.type.document
     - node.type.embargoed_publication
+  module:
+    - file
 id: node.embargoed_publication.field_secure_attachment
 field_name: field_secure_attachment
 entity_type: node
 bundle: embargoed_publication
 label: Documents
 description: |
-  Choose at least between one and five individual files to attach to this embargoed publication revision.<br>
-  <br>
+  <p>Choose at least between one and five individual files to attach to this embargoed publication revision.</p>
   <strong>An important note about attachments:</strong>
   <ul>
   <li>Multiple revisions of a publication page can link to the same file attachment.</li>
   <li>If you need to make a new version of a file available within a publication revision, attach a new file with a different filename and remove the old file attachment (this will not affect other revisions of the publication - these will still have the old file attached).</li>
   </ul>
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:media'
-  handler_settings:
-    target_bundles:
-      document: document
-    sort:
-      field: _none
-    auto_create: false
-    auto_create_bundle: ''
-field_type: entity_reference
+  file_directory: secure_attachment
+  file_extensions: 'pdf doc docx xls xlsx xlsm ppt pptx odt ods odp dot zip'
+  max_filesize: 30MB
+  description_field: true
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/sync/field.storage.node.field_secure_attachment.yml
+++ b/config/sync/field.storage.node.field_secure_attachment.yml
@@ -1,17 +1,20 @@
-uuid: 00e59dde-0f1c-40b5-81f3-4847b85529f0
+uuid: a17509cc-4193-4d49-af93-e10e1a28a68d
 langcode: en
 status: true
 dependencies:
   module:
-    - media
+    - file
     - node
 id: node.field_secure_attachment
 field_name: field_secure_attachment
 entity_type: node
-type: entity_reference
+type: file
 settings:
-  target_type: media
-module: core
+  display_field: false
+  display_default: false
+  uri_scheme: private
+  target_type: file
+module: file
 locked: false
 cardinality: -1
 translatable: true


### PR DESCRIPTION
Ensures we don't need to stick two file fields on Document entities; one for private one for public storage.