### PR TITLE
Drop internal cron so we can use external service

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -135,9 +135,3 @@ web:
         # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
         '^/sites/default/files/(css|js)':
           expires: 2w
-
-# The configuration of scheduled execution.
-crons:
-  drupal:
-    spec: '*/5 * * * *'
-    cmd: 'cd web ; drush core-cron'


### PR DESCRIPTION
We're likely going to use GCP Scheduler to kick off the HTTP requests for cron as it can reliably execute every 60 seconds.
