### PR TITLE
Add APCu extension

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,6 +16,7 @@ dependencies:
 runtime:
   # Enable the redis extension so Drupal can communicate with the Redis cache.
   extensions:
+    - apcu
     - redis
 
 # The relationships of the application with services or other applications.


### PR DESCRIPTION
Allows PHP 7.4 to make use of this opcache, which should give some performance improvements.