### PR TITLE
Use 9.x compatible version of the module, and patch to fix drush command error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "drupal/views_custom_cache_tag": "^1.1",
         "drupal/views_data_export": "^1.0",
         "drupal/webform": "^6.0",
-        "drupal/whatlinkshere": "^1.6",
+        "drupal/whatlinkshere": "^2.0",
         "drupal/xls_serialization": "^1.2",
         "drush/drush": "^10.1",
         "harvesthq/chosen": "^1.8",
@@ -198,7 +198,8 @@
                 "'Draft available' text still appears after deleting a forward revision": "https://www.drupal.org/files/issues/2020-02-24/3115474-3.patch"
             },
             "drupal/whatlinkshere": {
-                "Incorrect batch id in drush command": "https://www.drupal.org/files/issues/2021-01-26/fix-batch-id-ref.patch"
+                "Incorrect batch id in drush command": "https://www.drupal.org/files/issues/2021-01-26/fix-batch-id-ref.patch",
+                "EntityTypeManager in constructor should use interface for better module compatibility": "https://www.drupal.org/files/issues/2021-03-08/fix-drush-command-constructor.patch"
             },
             "drupal/hms_field": {
                 "Drupal 8.9 / 9 compatibility": "https://www.drupal.org/files/issues/2020-06-05/3145496-6.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c210139de66d009a9a234540b3610a1",
+    "content-hash": "3489ed9990b1e98f29e3708c3b6d5857",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -8039,17 +8039,17 @@
         },
         {
             "name": "drupal/whatlinkshere",
-            "version": "1.7.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/whatlinkshere.git",
-                "reference": "8.x-1.7"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/whatlinkshere-8.x-1.7.zip",
-                "reference": "8.x-1.7",
-                "shasum": "991f16731620e3ebd2ba7d4ae0d223a8a99d83d1"
+                "url": "https://ftp.drupal.org/files/projects/whatlinkshere-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "0f9a9e45919616a0020fcc6db17b62ef01c2c3a5"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -8057,8 +8057,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.7",
-                    "datestamp": "1611582479",
+                    "version": "2.0.2",
+                    "datestamp": "1611582444",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -8068,9 +8068,6 @@
                     "services": {
                         "drush.services.yml": "^10"
                     }
-                },
-                "patches_applied": {
-                    "Incorrect batch id in drush command": "https://www.drupal.org/files/issues/2021-01-26/fix-batch-id-ref.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -18169,10 +18166,10 @@
     ],
     "aliases": [
         {
-            "alias": "3.4.41",
-            "alias_normalized": "3.4.41.0",
+            "package": "symfony/event-dispatcher",
             "version": "4.3.11.0",
-            "package": "symfony/event-dispatcher"
+            "alias": "3.4.41",
+            "alias_normalized": "3.4.41.0"
         }
     ],
     "minimum-stability": "dev",
@@ -18202,5 +18199,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
An expected module update, but need the patch in there too to fix an otherwise fatal error when enabling some modules like webprofiler.