### PR TITLE
D8NID-1129

### DIFF
--- a/config/sync/block.block.featuredcontent_covid19.yml
+++ b/config/sync/block.block.featuredcontent_covid19.yml
@@ -1,4 +1,4 @@
-uuid: 52363a5e-401c-4107-99d1-454125821310
+uuid: 6d3d63bc-7093-47ef-a2e8-8f826c33339f
 langcode: en
 status: true
 dependencies:
@@ -7,18 +7,18 @@ dependencies:
     - system
   theme:
     - nicsdru_nidirect_theme
-id: featuredcontent
+id: featuredcontent_covid19
 theme: nicsdru_nidirect_theme
-region: bottom_banner
-weight: -17
+region: content
+weight: -16
 provider: null
 plugin: featured_content
 settings:
   id: featured_content
-  label: Featured
+  label: 'Featured content: COVID-19'
   provider: nidirect_homepage
-  label_display: visible
-  featured_items: '14474'
+  label_display: '0'
+  featured_items: '14485'
 visibility:
   request_path:
     id: request_path

--- a/config/sync/block.block.mainpagecontent.yml
+++ b/config/sync/block.block.mainpagecontent.yml
@@ -9,7 +9,7 @@ dependencies:
 id: mainpagecontent
 theme: nicsdru_nidirect_theme
 region: content
-weight: -16
+weight: -17
 provider: null
 plugin: system_main_block
 settings:

--- a/config/sync/block.block.pagetitle.yml
+++ b/config/sync/block.block.pagetitle.yml
@@ -9,7 +9,7 @@ dependencies:
 id: pagetitle
 theme: nicsdru_nidirect_theme
 region: content
-weight: -17
+weight: -18
 provider: null
 plugin: page_title_block
 settings:

--- a/config/sync/block.block.pagetitle_banner_top.yml
+++ b/config/sync/block.block.pagetitle_banner_top.yml
@@ -9,7 +9,7 @@ dependencies:
 id: pagetitle_banner_top
 theme: nicsdru_nidirect_theme
 region: top_banner
-weight: -17
+weight: -18
 provider: null
 plugin: page_title_block
 settings:

--- a/config/sync/block.block.primaryadminactions.yml
+++ b/config/sync/block.block.primaryadminactions.yml
@@ -7,7 +7,7 @@ dependencies:
 id: primaryadminactions
 theme: nicsdru_nidirect_theme
 region: top_banner
-weight: -18
+weight: -19
 provider: null
 plugin: local_actions_block
 settings:

--- a/config/sync/block.block.tabs.yml
+++ b/config/sync/block.block.tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: tabs
 theme: nicsdru_nidirect_theme
 region: top_banner
-weight: -15
+weight: -17
 provider: null
 plugin: local_tasks_block
 settings:

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -68,25 +68,11 @@ if (!empty(getenv('PLATFORM_BRANCH'))) {
     case 'main':
       // De-facto production settings.
       $config['config_split.config_split.production']['status'] = TRUE;
-      $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
-      break;
-
-    case 'D8NID-edge':
-      // Retain as much production related config/settings as possible.
-      $config['config_split.config_split.production']['status'] = TRUE;
-      $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
-      break;
-
-    case (stripos(getenv('PLATFORM_BRANCH'), 'D8NID-qa') !== FALSE):
-      // QA environment config adjustments.
-      $env_colour = '#e56716';
       break;
 
     default:
       // Default to use development settings/services for general platform.sh environments.
       $config['config_split.config_split.development']['status'] = TRUE;
-      $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.development.yml';
-      include $app_root . '/' . $site_path . '/settings.development.php';
   }
 }
 


### PR DESCRIPTION
NB: COVID-19 block node id liable to shift with migrations, so block config may need to be updated to reflect a shifting high water line for content ids after each migration run.