### PR TITLE
Block layout changes 

### DIFF
--- a/config/sync/block.block.featuredcontent.yml
+++ b/config/sync/block.block.featuredcontent.yml
@@ -10,7 +10,7 @@ dependencies:
 id: featuredcontent
 theme: nicsdru_nidirect_theme
 region: bottom_banner
-weight: -17
+weight: -18
 provider: null
 plugin: featured_content
 settings:
@@ -18,7 +18,7 @@ settings:
   label: Featured
   provider: nidirect_homepage
   label_display: visible
-  featured_items: '14474'
+  featured_items: '14730'
 visibility:
   request_path:
     id: request_path

--- a/config/sync/block.block.featuredcontent_covid19.yml
+++ b/config/sync/block.block.featuredcontent_covid19.yml
@@ -9,8 +9,8 @@ dependencies:
     - nicsdru_nidirect_theme
 id: featuredcontent_covid19
 theme: nicsdru_nidirect_theme
-region: content
-weight: -16
+region: top_banner
+weight: -15
 provider: null
 plugin: featured_content
 settings:
@@ -18,7 +18,7 @@ settings:
   label: 'Featured content: COVID-19'
   provider: nidirect_homepage
   label_display: '0'
-  featured_items: '14485'
+  featured_items: '14736'
 visibility:
   request_path:
     id: request_path

--- a/config/sync/block.block.featurednews.yml
+++ b/config/sync/block.block.featurednews.yml
@@ -10,7 +10,7 @@ dependencies:
 id: featurednews
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -13
+weight: -14
 provider: null
 plugin: featured_news_block
 settings:

--- a/config/sync/block.block.healthconditionsatoz_sidebar_2.yml
+++ b/config/sync/block.block.healthconditionsatoz_sidebar_2.yml
@@ -10,7 +10,7 @@ dependencies:
 id: healthconditionsatoz_sidebar_2
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -15
+weight: -16
 provider: null
 plugin: healthconditions_az_block
 settings:

--- a/config/sync/block.block.healthconditionsfacetsummary.yml
+++ b/config/sync/block.block.healthconditionsfacetsummary.yml
@@ -12,7 +12,7 @@ dependencies:
 id: healthconditionsfacetsummary
 theme: nicsdru_nidirect_theme
 region: content
-weight: -14
+weight: -15
 provider: null
 plugin: 'facets_summary_block:health_conditions_facet_summary'
 settings:

--- a/config/sync/block.block.healthconditionsrelatedconditions.yml
+++ b/config/sync/block.block.healthconditionsrelatedconditions.yml
@@ -10,7 +10,7 @@ dependencies:
 id: healthconditionsrelatedconditions
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -14
+weight: -15
 provider: null
 plugin: healthconditions_related_conditions
 settings:

--- a/config/sync/block.block.metofficeweather.yml
+++ b/config/sync/block.block.metofficeweather.yml
@@ -12,7 +12,7 @@ dependencies:
 id: metofficeweather
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -9
+weight: -11
 provider: null
 plugin: 'block_content:2ae061ef-9916-4238-bfb4-a0e9d84a6d15'
 settings:

--- a/config/sync/block.block.originssocialsharing.yml
+++ b/config/sync/block.block.originssocialsharing.yml
@@ -11,7 +11,7 @@ dependencies:
 id: originssocialsharing
 theme: nicsdru_nidirect_theme
 region: content
-weight: -13
+weight: -14
 provider: null
 plugin: origins_social_sharing
 settings:

--- a/config/sync/block.block.pagetitle_banner_top.yml
+++ b/config/sync/block.block.pagetitle_banner_top.yml
@@ -9,7 +9,7 @@ dependencies:
 id: pagetitle_banner_top
 theme: nicsdru_nidirect_theme
 region: top_banner
-weight: -18
+weight: -17
 provider: null
 plugin: page_title_block
 settings:
@@ -21,6 +21,7 @@ visibility:
   request_path:
     id: request_path
     pages: |
+      <front>
       /publications
       /publications/date/*
       /publications/topic/*

--- a/config/sync/block.block.primaryadminactions.yml
+++ b/config/sync/block.block.primaryadminactions.yml
@@ -7,7 +7,7 @@ dependencies:
 id: primaryadminactions
 theme: nicsdru_nidirect_theme
 region: top_banner
-weight: -19
+weight: -18
 provider: null
 plugin: local_actions_block
 settings:

--- a/config/sync/block.block.relatedcontentblock.yml
+++ b/config/sync/block.block.relatedcontentblock.yml
@@ -10,7 +10,7 @@ dependencies:
 id: relatedcontentblock
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -17
+weight: -18
 provider: null
 plugin: nidirect_related_content_block
 settings:

--- a/config/sync/block.block.tabs.yml
+++ b/config/sync/block.block.tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: tabs
 theme: nicsdru_nidirect_theme
 region: top_banner
-weight: -17
+weight: -16
 provider: null
 plugin: local_tasks_block
 settings:

--- a/config/sync/block.block.translationhelplink.yml
+++ b/config/sync/block.block.translationhelplink.yml
@@ -10,7 +10,7 @@ dependencies:
 id: translationhelplink
 theme: nicsdru_nidirect_theme
 region: bottom_banner
-weight: 0
+weight: -17
 provider: null
 plugin: translation_help_block
 settings:

--- a/config/sync/block.block.views_block__popular_content_pop_by_term.yml
+++ b/config/sync/block.block.views_block__popular_content_pop_by_term.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__popular_content_pop_by_term
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -8
+weight: -10
 provider: null
 plugin: 'views_block:popular_content-pop_by_term'
 settings:

--- a/config/sync/block.block.views_block__popular_content_pop_info_site_wide.yml
+++ b/config/sync/block.block.views_block__popular_content_pop_info_site_wide.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__popular_content_pop_info_site_wide
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -11
+weight: -13
 provider: null
 plugin: 'views_block:popular_content-pop_info_site_wide'
 settings:

--- a/config/sync/block.block.views_block__popular_content_pop_services_site_wide.yml
+++ b/config/sync/block.block.views_block__popular_content_pop_services_site_wide.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__popular_content_pop_services_site_wide
 theme: nicsdru_nidirect_theme
 region: sidebar_second
-weight: -10
+weight: -12
 provider: null
 plugin: 'views_block:popular_content-pop_services_site_wide'
 settings:

--- a/config/sync/block.block.views_block__site_themes_site_themes_home_page.yml
+++ b/config/sync/block.block.views_block__site_themes_site_themes_home_page.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__site_themes_site_themes_home_page
 theme: nicsdru_nidirect_theme
 region: content
-weight: -15
+weight: -16
 provider: null
 plugin: 'views_block:site_themes-site_themes_home_page'
 settings:


### PR DESCRIPTION
Move the featured content block for covid-19 features into the top banner region.  There are changes to featured items node ids for the two featured content blocks - but I don't think this should break anything because these ids are set by env variables on edge.