### PR TITLE
Drop upgrade_status module usage; fall back to using phpstan/drupal-check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ commands:
           name: Fetch dependencies with composer
           command: |
             composer install --no-interaction --optimize-autoloader
-
   install_php_os_extensions:
     description: "Install a standard group of extensions and packages"
     steps:
@@ -114,7 +113,7 @@ jobs:
             - ./
 
   # Test for coding standards.
-  static_analysis:
+  coding_standards:
     docker:
       - image: circleci/php:7.4.15-apache-browsers
     steps:
@@ -122,8 +121,21 @@ jobs:
           at: ./
       - run: sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
       - run:
-          name: PHPCS static analysis
+          name: PHPCS analysis
           command: /home/circleci/project/phpcs.sh /home/circleci/project "/home/circleci/project/web/modules/origins /home/circleci/project/web/modules/custom /home/circleci/project/web/modules/migrate /home/circleci/project/web/themes/custom"
+
+  deprecated_code:
+    docker:
+      - image: circleci/php:7.4.15-apache-browsers
+    steps:
+      - attach_workspace:
+          at: ./
+      - run: sudo cp /home/circleci/project/.circleci/docker-php-circleci.ini /usr/local/etc/php/conf.d/
+      - run:
+          name: Deprecated code check
+          command: |
+            cd /home/circleci/project
+            vendor/bin/drupal-check /home/circleci/project/web/modules/custom /home/circleci/project/web/modules/origins /home/circleci/project/web/modules/migrate /home/circleci/project/web/themes/custom -e "*/tests/src/*"
 
   # Run any unit tests and any kernel tests against a vanilla D8 site + our site config imported over it (no predefined content).
   unit_kernel_tests:
@@ -290,22 +302,6 @@ jobs:
           paths:
             - ./
 
-  # Code analysis using upgrade_status module; run against platform.sh environment because
-  # initiating/installing against Circle CI containers takes a long time indeed.
-  code_analysis:
-    docker:
-      - image: circleci/php:7.4.15-apache-browsers
-    steps:
-      - attach_workspace:
-          at: ./
-      - install_php_os_extensions
-      - install_platformsh_tools
-      - run:
-          name: "Invoke upgrade_status drush command"
-          command: |
-            /home/circleci/.platformsh/bin/platform environment:drush "en upgrade_status -y" -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
-            /home/circleci/.platformsh/bin/platform environment:drush "upgrade_status:analyze --all --ignore-contrib --ignore-uninstalled" -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
-
   # Separate task to allow us to sync data on PSH environments, without pauses in other jobs.
   sync_data:
     docker:
@@ -382,7 +378,10 @@ workflows:
   build-test-deploy:
     jobs:
       - build
-      - static_analysis:
+      - coding_standards:
+          requires:
+            - build
+      - deprecated_code:
           requires:
             - build
       - unit_kernel_tests:
@@ -401,7 +400,10 @@ workflows:
                 - development
     jobs:
       - build
-      - static_analysis:
+      - coding_standards:
+          requires:
+            - build
+      - deprecated_code:
           requires:
             - build
       - unit_kernel_tests:
@@ -410,9 +412,6 @@ workflows:
       - edge_build:
           requires:
             - build
-      - code_analysis:
-          requires:
-            - edge_build
 
   # A separate scheduled workflow to sync the data after the nightly build completes.
   # This is separate to avoid using build time/compute units with arbitrary sleep commands;

--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,7 @@
         "drupal/stage_file_proxy": "^1.0@beta",
         "drupal/upgrade_status": "^3.0",
         "kint-php/kint": "^3.3",
+        "mglaman/drupal-check": "^1.1",
         "previousnext/phpunit-finder": "^1.0@alpha",
         "thinktandem/migrate_booster": "dev-main"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "330ddc8d68f7acf8ba936c4a6cb5675f",
+    "content-hash": "dd9182abe51667ed106f293a2c0b1049",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -16506,6 +16506,65 @@
             "time": "2016-12-01T10:57:30+00:00"
         },
         {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "b2c4ec2033a0196317a467cb197c7c843b794ddf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/b2c4ec2033a0196317a467cb197c7c843b794ddf",
+                "reference": "b2c4ec2033a0196317a467cb197c7c843b794ddf",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^0.12.66",
+                "phpunit/phpunit": "^7.5|^8.5|^9.4",
+                "vimeo/psalm": "^4.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.3"
+            },
+            "time": "2021-02-22T10:52:38+00:00"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "5.2.10",
             "source": {
@@ -16848,6 +16907,81 @@
             "time": "2020-06-23T17:14:22+00:00"
         },
         {
+            "name": "mglaman/drupal-check",
+            "version": "1.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mglaman/drupal-check.git",
+                "reference": "58549723fb306112ca367861a6e03032edc3d285"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mglaman/drupal-check/zipball/58549723fb306112ca367861a6e03032edc3d285",
+                "reference": "58549723fb306112ca367861a6e03032edc3d285",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^1.3",
+                "jean85/pretty-package-versions": "^1.5.0 || ^2.0.1",
+                "mglaman/phpstan-drupal": "^0.12.8",
+                "nette/neon": "^3.1",
+                "php": "^7.2.5|^8.0",
+                "phpstan/phpstan-deprecation-rules": "^0.12.6",
+                "symfony/console": "~3.2 || ~4.0",
+                "symfony/process": "~3.2 || ~4.0",
+                "webflo/drupal-finder": "^1.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.81",
+                "phpstan/phpstan-strict-rules": "^0.12.9",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "bin": [
+                "drupal-check"
+            ],
+            "type": "project",
+            "extra": {
+                "violinist": {
+                    "one_pull_request_per_package": 1
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DrupalCheck\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Glaman",
+                    "email": "nmd.matt@gmail.com"
+                }
+            ],
+            "description": "CLI tool for running checks on a Drupal code base",
+            "support": {
+                "issues": "https://github.com/mglaman/drupal-check/issues",
+                "source": "https://github.com/mglaman/drupal-check/tree/1.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mglaman",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/phpstan-drupal",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/mglaman/drupal-check",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-17T21:31:35+00:00"
+        },
+        {
             "name": "mglaman/phpstan-drupal",
             "version": "0.12.9",
             "source": {
@@ -17123,6 +17257,71 @@
                 "source": "https://github.com/nette/finder/tree/v2.5.2"
             },
             "time": "2020-01-03T20:35:40+00:00"
+        },
+        {
+            "name": "nette/neon",
+            "version": "v3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "e4ca6f4669121ca6876b1d048c612480e39a28d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/e4ca6f4669121ca6876b1d048c612480e39a28d5",
+                "reference": "e4ca6f4669121ca6876b1d048c612480e39a28d5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "homepage": "https://ne-on.org",
+            "keywords": [
+                "export",
+                "import",
+                "neon",
+                "nette",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/neon/issues",
+                "source": "https://github.com/nette/neon/tree/v3.2.2"
+            },
+            "time": "2021-02-28T12:30:32+00:00"
         },
         {
             "name": "nette/utils",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -191,7 +191,6 @@ module:
   twig_tweak: 0
   ultimate_cron: 0
   update: 0
-  upgrade_status: 0
   user: 0
   views_contextual_filters_or: 0
   views_custom_cache_tag: 0

--- a/config/sync/upgrade_status.settings.yml
+++ b/config/sync/upgrade_status.settings.yml
@@ -1,3 +1,0 @@
-paths_per_scan: 30
-_core:
-  default_config_hash: BqkUHiXXGvu2L7NR_nblxtP6f03MdD16XSMWwVM0QEc


### PR DESCRIPTION
CI steps might fail as I've twiddled the job names and that won't match up with broader repo config. I've done this to split the coding standards from deprecated code checks; these can run in parallel.