### PR TITLE
Add devel config

### DIFF
--- a/config/sync/devel.settings.yml
+++ b/config/sync/devel.settings.yml
@@ -1,0 +1,8 @@
+page_alter: false
+raw_names: false
+error_handlers:
+  1: 1
+rebuild_theme: false
+devel_dumper: default
+debug_logfile: 'temporary://drupal_debug.txt'
+debug_pre: false


### PR DESCRIPTION
Undefined error handler means PHP errors are all rendered to output which isn't desirable