### PR TITLE
D8NID-1189 CSP module and config

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -144,3 +144,8 @@ web:
         # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
         '^/sites/default/files/(css|js)':
           expires: 2w
+crons:
+  # Once a day, prune/delete filelog entries older than 4 weeks.
+  filelog:
+    spec: '0 1 * * *'
+    cmd: 'cd /app/private; find logs -mtime +4w -exec rm -rf {} \;'

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -145,7 +145,7 @@ web:
         '^/sites/default/files/(css|js)':
           expires: 2w
 crons:
-  # Once a day, prune/delete filelog entries older than 4 weeks.
+  # Once a day, prune/delete filelog entries older than 30 days.
   filelog:
     spec: '0 1 * * *'
-    cmd: 'cd /app/private; find logs -mtime +4w -exec rm -rf {} \;'
+    cmd: 'cd /app/private; find logs -mtime +30 -exec rm -rf {} \;'

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "drupal/core-composer-scaffold": "^8.9.13",
         "drupal/core-project-message": "^8.9.13",
         "drupal/core-recommended": "^8.9.13",
+        "drupal/csp": "^1.15",
         "drupal/csv_serialization": "^2.0@beta",
         "drupal/diff": "^1.0",
         "drupal/entity_browser": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
         "drupal/facets_pretty_paths": "1.x-dev",
         "drupal/fastly": "^3.9",
         "drupal/field_group": "^3.0",
+        "drupal/filelog": "^2.0",
         "drupal/flag": "4.x-dev",
         "drupal/geocoder": "^3.14",
         "drupal/geolocation": "3.x",
@@ -247,6 +248,9 @@
             },
             "drupal/entity_reference_unpublished": {
                 "Plugin to cover taxonomy term entities": "https://www.drupal.org/files/issues/2021-03-25/3205634-reference-unpublished-taxonomy-terms.patch"
+            },
+            "drupal/filelog": {
+                "Whole Log gets loaded into Memory when gzipping": "https://www.drupal.org/files/issues/2021-04-07/filelog-3157650-21.patch"
             }
         },
         "composer-exit-on-patch-failure": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9895c40ee80bfa163ad1b9f0991913b4",
+    "content-hash": "6f0ef98453ca8cec34f7d4358d11f0b7",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -4005,6 +4005,60 @@
                 "source": "https://github.com/drupal/core-recommended/tree/8.9.14"
             },
             "time": "2021-04-20T23:05:40+00:00"
+        },
+        {
+            "name": "drupal/csp",
+            "version": "1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/csp.git",
+                "reference": "8.x-1.15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/csp-8.x-1.15.zip",
+                "reference": "8.x-1.15",
+                "shasum": "fbb6c4d2cb25c53758b7286f161c3c1a511ff8d1"
+            },
+            "require": {
+                "drupal/core": "^8.5 || ^9.0",
+                "ext-json": "*",
+                "php": ">=7.2"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.15",
+                    "datestamp": "1618259686",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "gapple",
+                    "homepage": "https://www.drupal.org/user/490940"
+                },
+                {
+                    "name": "rfsbsb",
+                    "homepage": "https://www.drupal.org/user/4382"
+                }
+            ],
+            "description": "Provide Content-Security-Policy headers",
+            "homepage": "https://www.drupal.org/project/csp",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/csp",
+                "issues": "https://www.drupal.org/project/issues/csp"
+            }
         },
         {
             "name": "drupal/csv_serialization",

--- a/composer.lock
+++ b/composer.lock
@@ -5167,6 +5167,58 @@
             }
         },
         {
+            "name": "drupal/filelog",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/filelog.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/filelog-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "b02a3557a4c59bfa48582c54db062de9c7805721"
+            },
+            "require": {
+                "drupal/core": "^8.8 | ^9",
+                "ext-zlib": "*",
+                "php": "^7.1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1592209031",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Burschka",
+                    "homepage": "https://github.com/cburschka",
+                    "email": "christoph@burschka.de",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Logs system events to a file.",
+            "homepage": "https://www.drupal.org/project/filelog",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/filelog",
+                "issues": "https://www.drupal.org/project/issues/filelog"
+            }
+        },
+        {
             "name": "drupal/flag",
             "version": "dev-4.x",
             "source": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f0ef98453ca8cec34f7d4358d11f0b7",
+    "content-hash": "b1759dcd4d3ac493aa0d7f2f2d57678c",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -4131,7 +4131,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-3.5",
-                    "datestamp": "1618592931",
+                    "datestamp": "1620838181",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4833,7 +4833,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.5",
-                    "datestamp": "1595015391",
+                    "datestamp": "1620838256",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -50,6 +50,7 @@ module:
   field_group: 0
   field_ui: 0
   file: 0
+  filelog: 0
   filter: 0
   flag: 0
   geocoder: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -25,6 +25,7 @@ module:
   content_moderation: 0
   contextual: 0
   cookie_content_blocker: 0
+  csp: 0
   csv_serialization: 0
   ctools: 0
   ctools_entity_mask: 0

--- a/config/sync/csp.settings.yml
+++ b/config/sync/csp.settings.yml
@@ -1,0 +1,59 @@
+_core:
+  default_config_hash: o4-eDkmTmVdUICtL1VxWD3S9Ze8kNq_lHj6DskF8U8o
+report-only:
+  enable: false
+  directives:
+    default-src:
+      base: self
+    script-src:
+      base: self
+    script-src-attr:
+      base: self
+    script-src-elem:
+      base: self
+    style-src:
+      base: self
+    style-src-attr:
+      base: self
+    style-src-elem:
+      base: self
+    frame-ancestors:
+      base: self
+  reporting:
+    plugin: sitelog
+enforce:
+  enable: true
+  directives:
+    default-src:
+      base: self
+    font-src:
+      sources:
+        - themes.googleusercontent.com
+        - fonts.gstatic.com
+      base: self
+    frame-src:
+      sources:
+        - www.youtube.com
+        - www.youtube-nocookie.com
+      base: self
+    img-src:
+      sources:
+        - maps.gstatic.com
+        - maps.googleapis.com
+        - 'data:'
+      base: self
+    script-src:
+      sources:
+        - www.googletagmanager.com
+      base: self
+    style-src:
+      base: self
+    style-src-attr:
+      flags:
+        - unsafe-inline
+      base: self
+    frame-ancestors:
+      base: self
+    block-all-mixed-content: true
+  reporting:
+    plugin: sitelog

--- a/config/sync/csp.settings.yml
+++ b/config/sync/csp.settings.yml
@@ -1,27 +1,6 @@
 _core:
   default_config_hash: o4-eDkmTmVdUICtL1VxWD3S9Ze8kNq_lHj6DskF8U8o
 report-only:
-  enable: false
-  directives:
-    default-src:
-      base: self
-    script-src:
-      base: self
-    script-src-attr:
-      base: self
-    script-src-elem:
-      base: self
-    style-src:
-      base: self
-    style-src-attr:
-      base: self
-    style-src-elem:
-      base: self
-    frame-ancestors:
-      base: self
-  reporting:
-    plugin: sitelog
-enforce:
   enable: true
   directives:
     default-src:
@@ -31,11 +10,45 @@ enforce:
         - themes.googleusercontent.com
         - fonts.gstatic.com
       base: self
-    frame-src:
+    img-src:
       sources:
-        - www.youtube.com
-        - www.youtube-nocookie.com
+        - maps.gstatic.com
+        - maps.googleapis.com
+        - 'data:'
       base: self
+    script-src:
+      sources:
+        - www.googletagmanager.com
+      base: self
+    script-src-attr:
+      base: self
+    script-src-elem:
+      sources:
+        - www.googletagmanager.com
+      base: self
+    style-src:
+      base: self
+    style-src-attr:
+      flags:
+        - unsafe-inline
+      base: self
+    style-src-elem:
+      base: self
+    block-all-mixed-content: true
+  reporting:
+    plugin: sitelog
+enforce:
+  enable: false
+  directives:
+    default-src:
+      base: self
+    font-src:
+      sources:
+        - themes.googleusercontent.com
+        - fonts.gstatic.com
+      base: self
+    frame-src:
+      base: any
     img-src:
       sources:
         - maps.gstatic.com
@@ -53,7 +66,7 @@ enforce:
         - unsafe-inline
       base: self
     frame-ancestors:
-      base: self
+      base: any
     block-all-mixed-content: true
   reporting:
     plugin: sitelog

--- a/config/sync/csp.settings.yml
+++ b/config/sync/csp.settings.yml
@@ -10,6 +10,10 @@ report-only:
         - themes.googleusercontent.com
         - fonts.gstatic.com
       base: self
+    frame-src:
+      sources:
+        - www.youtube.com
+      base: self
     img-src:
       sources:
         - maps.gstatic.com
@@ -48,7 +52,9 @@ enforce:
         - fonts.gstatic.com
       base: self
     frame-src:
-      base: any
+      sources:
+        - www.youtube.com
+      base: self
     img-src:
       sources:
         - maps.gstatic.com

--- a/config/sync/filelog.settings.yml
+++ b/config/sync/filelog.settings.yml
@@ -1,0 +1,13 @@
+enabled: true
+location: 'private://logs'
+rotation:
+  schedule: daily
+  delete: false
+  destination: 'archive/[date:custom:Y/m/d].log'
+  gzip: true
+format: '[[log:created]] [[log:level]] [[log:channel]] [client: [log:ip], [log:user]] [log:message]'
+level: 7
+channels_type: exclude
+channels: {  }
+_core:
+  default_config_hash: uVSFqX1MwFixVjXjlh72ukQ8LKPgMKNi2raycY9vt3w


### PR DESCRIPTION
* Adds the content security policy module with report only config.
* Adds filelog module to avoid spraying a firehose of events at dblog (platform.sh can't support syslog)
* Cron handler to prune away compressed log files over 30 days old.