### PR TITLE
Landing pages block updates 2

### DIFF
--- a/config/sync/block_content.type.information_notice.yml
+++ b/config/sync/block_content.type.information_notice.yml
@@ -1,0 +1,8 @@
+uuid: 6d1fb652-84b7-40cb-9e47-f6628dba8dc0
+langcode: en
+status: true
+dependencies: {  }
+id: information_notice
+label: 'Information notice'
+revision: 1
+description: ''

--- a/config/sync/core.entity_form_display.block_content.information_notice.default.yml
+++ b/config/sync/core.entity_form_display.block_content.information_notice.default.yml
@@ -1,0 +1,40 @@
+uuid: 56914661-058d-4df1-95be-fbe76c18279c
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.information_notice
+    - field.field.block_content.information_notice.body
+  module:
+    - text
+id: block_content.information_notice.default
+targetEntityType: block_content
+bundle: information_notice
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 26
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.block_content.information_notice.default.yml
+++ b/config/sync/core.entity_view_display.block_content.information_notice.default.yml
@@ -1,0 +1,24 @@
+uuid: f4b31990-6511-4893-8542-5b154991ca8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.information_notice
+    - field.field.block_content.information_notice.body
+  module:
+    - text
+id: block_content.information_notice.default
+targetEntityType: block_content
+bundle: information_notice
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.landing_page.full.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.full.yml
@@ -33,7 +33,38 @@ third_party_settings:
         components: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
-    allowed_block_categories: {  }
+    allowed_block_categories:
+      - Block
+      - 'Chaos Tools'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - Facets
+      - 'Facets summary (Experimental)'
+      - Forms
+      - Geolocation
+      - Help
+      - 'Inline blocks'
+      - 'Landing pages'
+      - 'Lists (Views)'
+      - Menus
+      - 'NI Direct'
+      - NIDirect
+      - 'NIDirect Common'
+      - 'NIDirect Contacts'
+      - 'NIDirect Health Conditions'
+      - 'NIDirect Homepage'
+      - 'NIDirect News'
+      - 'Origins: Social Sharing'
+      - 'Site Themes (Views)'
+      - System
+      - 'Translation help link'
+      - User
+      - Views
+      - Webform
+      - 'Webform access'
+      - core
     entity_view_mode_restriction:
       whitelisted_blocks:
         Block: {  }
@@ -50,9 +81,11 @@ third_party_settings:
           - card_plain
           - card_standard
           - card_wide
+          - information_notice
           - text
           - video
           - video_and_caption
+        'Custom blocks': {  }
         Devel: {  }
         Facets: {  }
         'Facets summary (Experimental)': {  }
@@ -64,14 +97,17 @@ third_party_settings:
           - 'inline_block:article_teasers_by_topic'
           - 'inline_block:banner_deep'
           - 'inline_block:card_contact'
+          - 'inline_block:card_plain'
           - 'inline_block:card_standard'
           - 'inline_block:card_wide'
+          - 'inline_block:card_nested_standard'
+          - 'inline_block:card_nested_wide'
+          - 'inline_block:information_notice'
           - 'inline_block:card_deck_plain'
           - 'inline_block:text'
           - 'inline_block:video'
           - 'inline_block:video_and_caption'
-        'Landing pages':
-          - nidirect_landing_pages_health_conditions_search_and_a_z
+        'Landing pages': {  }
         'Lists (Views)': {  }
         Menus: {  }
         'NI Direct': {  }
@@ -102,7 +138,7 @@ third_party_settings:
         - teasers_x2
       whitelisted_blocks:
         layout_onecol:
-          content:
+          all_regions:
             Block: {  }
             'Chaos Tools': {  }
             'Content fields': {  }
@@ -110,9 +146,9 @@ third_party_settings:
               - accordion_menu
               - article_teasers_by_topic
               - banner_deep
-              - basic
               - card_contact
               - card_deck_plain
+              - information_notice
               - text
               - video_and_caption
             'Custom blocks': {  }
@@ -126,11 +162,12 @@ third_party_settings:
               - 'inline_block:accordion_menu'
               - 'inline_block:article_teasers_by_topic'
               - 'inline_block:banner_deep'
-              - 'inline_block:basic'
               - 'inline_block:card_contact'
+              - 'inline_block:information_notice'
               - 'inline_block:card_deck_plain'
               - 'inline_block:text'
               - 'inline_block:video_and_caption'
+            'Landing pages': {  }
             'Lists (Views)': {  }
             Menus: {  }
             'NI Direct': {  }
@@ -156,6 +193,7 @@ third_party_settings:
             'Content fields': {  }
             'Custom block types':
               - card_contact
+              - card_nested_wide
               - card_wide
               - video
             'Custom blocks': {  }
@@ -168,6 +206,7 @@ third_party_settings:
             'Inline blocks':
               - 'inline_block:card_contact'
               - 'inline_block:card_wide'
+              - 'inline_block:card_nested_wide'
               - 'inline_block:video'
             'Lists (Views)': {  }
             Menus: {  }
@@ -194,6 +233,7 @@ third_party_settings:
             'Content fields': {  }
             'Custom block types':
               - card_contact
+              - card_nested_standard
               - card_standard
             'Custom blocks': {  }
             Devel: {  }
@@ -205,6 +245,7 @@ third_party_settings:
             'Inline blocks':
               - 'inline_block:card_contact'
               - 'inline_block:card_standard'
+              - 'inline_block:card_nested_standard'
             'Lists (Views)': {  }
             Menus: {  }
             'NI Direct': {  }

--- a/config/sync/editor.editor.layout_builder_html.yml
+++ b/config/sync/editor.editor.layout_builder_html.yml
@@ -50,7 +50,6 @@ settings:
   plugins:
     stylescombo:
       styles: |
-        p.info-notice|Information notice
         p.large-text|Large text
         p.xl-text|Extra large text
         a.btn--call-to-action|Big green button

--- a/config/sync/field.field.block_content.information_notice.body.yml
+++ b/config/sync/field.field.block_content.information_notice.body.yml
@@ -1,0 +1,23 @@
+uuid: 4d85a43a-2561-4ba2-99e3-3b9941cb29bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.information_notice
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.information_notice.body
+field_name: body
+entity_type: block_content
+bundle: information_notice
+label: Body
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/sync/language.content_settings.block_content.information_notice.yml
+++ b/config/sync/language.content_settings.block_content.information_notice.yml
@@ -1,0 +1,11 @@
+uuid: 1e0c7bae-4c6a-4d0b-9fa4-7ca8488d61f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.information_notice
+id: block_content.information_notice
+target_entity_type_id: block_content
+target_bundle: information_notice
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/layout_builder_restrictions.plugins.yml
+++ b/config/sync/layout_builder_restrictions.plugins.yml
@@ -4,4 +4,4 @@ plugin_config:
     enabled: true
   entity_view_mode_restriction_by_region:
     weight: 1
-    enabled: false
+    enabled: true


### PR DESCRIPTION
- Add information notice block for landing pages (to be used instead of ckeditor info-notice style on the text block)
- Re-enable layout builder block restrictions by region to ensure editors cannot, for example, add cards into the one column layout section or add information notice blocks into x2 and x3 card sections.
- Remove p.info-notice style from layout builder text format