### PR TITLE
Set logger factory priority to mediate between fastly and filelog module services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -183,7 +183,8 @@
                 "Off-canvas style resets are overriding styles (especially SVGs) in Safari, Firefox and Chromium Edge resulting in display issues": "https://www.drupal.org/files/issues/2021-01-06/off-canvas-style-resets-2958588-13.patch",
                 "Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2020-10-18/2918537-63.patch",
                 "Layout builder fails to assign inline block access dependencies for the overrides section storage on entities with pending revisions": "https://www.drupal.org/files/issues/2021-03-22/3047022-70-backport-8.9.x.patch",
-                "Support for AjaxResponse implementing CacheableResponseInterface": "https://gist.githubusercontent.com/omahm/cd990b5cdba637fe270ada0702717d9d/raw/60a05babb9747061df201ca9f74afb4b59166f14/cacheableAjaxResponse.patch"
+                "Support for AjaxResponse implementing CacheableResponseInterface": "https://gist.githubusercontent.com/omahm/cd990b5cdba637fe270ada0702717d9d/raw/60a05babb9747061df201ca9f74afb4b59166f14/cacheableAjaxResponse.patch",
+                "Increase service priority for logger factory": "https://gist.githubusercontent.com/johangant/3023926f40867e14385bd3d87831adfc/raw/174cec09449636263b8dcd01679945677a0d607d/increase_logger_factory_service_priority.patch"
             },
             "drupal/easy_install": {
                 "Handle missing core version": "https://www.drupal.org/files/issues/2019-12-19/easy_install_core_version-3101883-0.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1759dcd4d3ac493aa0d7f2f2d57678c",
+    "content-hash": "8fb288f4ba4117bb209724efc5ee4b4a",
     "packages": [
         {
             "name": "alchemy/zippy",

--- a/composer.lock
+++ b/composer.lock
@@ -2161,16 +2161,16 @@
         },
         {
             "name": "dof-dss/nicsdru_origins_modules",
-            "version": "0.9.20",
+            "version": "0.9.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dof-dss/nicsdru_origins_modules.git",
-                "reference": "2b64f17b91d0716df90922d1f849e7252cbd866d"
+                "reference": "1cbae97792d8e391f0dd54da9b770a994242245d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nicsdru_origins_modules/zipball/2b64f17b91d0716df90922d1f849e7252cbd866d",
-                "reference": "2b64f17b91d0716df90922d1f849e7252cbd866d",
+                "url": "https://api.github.com/repos/dof-dss/nicsdru_origins_modules/zipball/1cbae97792d8e391f0dd54da9b770a994242245d",
+                "reference": "1cbae97792d8e391f0dd54da9b770a994242245d",
                 "shasum": ""
             },
             "require": {
@@ -2184,9 +2184,9 @@
             "description": "Generic modules for DOF-DSS Drupal sites",
             "support": {
                 "issues": "https://github.com/dof-dss/nicsdru_origins_modules/issues",
-                "source": "https://github.com/dof-dss/nicsdru_origins_modules/tree/0.9.20"
+                "source": "https://github.com/dof-dss/nicsdru_origins_modules/tree/0.9.21"
             },
-            "time": "2021-05-11T13:18:38+00:00"
+            "time": "2021-05-16T20:11:31+00:00"
         },
         {
             "name": "dof-dss/nicsdru_origins_theme",
@@ -2288,16 +2288,16 @@
         },
         {
             "name": "dof-dss/nidirect-site-modules",
-            "version": "0.12.6",
+            "version": "0.12.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dof-dss/nidirect-site-modules.git",
-                "reference": "cc864330d6410268c88b5f301c0d2ada56158d67"
+                "reference": "1054fad9f363ade8e538565246ad5a9ffcfb608c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nidirect-site-modules/zipball/cc864330d6410268c88b5f301c0d2ada56158d67",
-                "reference": "cc864330d6410268c88b5f301c0d2ada56158d67",
+                "url": "https://api.github.com/repos/dof-dss/nidirect-site-modules/zipball/1054fad9f363ade8e538565246ad5a9ffcfb608c",
+                "reference": "1054fad9f363ade8e538565246ad5a9ffcfb608c",
                 "shasum": ""
             },
             "require": {
@@ -2311,9 +2311,9 @@
             ],
             "description": "Drupal modules to provide custom code for NI Direct",
             "support": {
-                "source": "https://github.com/dof-dss/nidirect-site-modules/tree/0.12.6"
+                "source": "https://github.com/dof-dss/nidirect-site-modules/tree/0.12.7"
             },
-            "time": "2021-05-12T19:18:19+00:00"
+            "time": "2021-05-16T20:09:38+00:00"
         },
         {
             "name": "drupal/address",


### PR DESCRIPTION
Relates to https://www.drupal.org/project/filelog/issues/3133252, surfaces itself with a clash between core/fastly and filelog modules.

Nudging the logger factory priority ensures it's loaded before the file system service and avoids a circular dependency issue.