### PR TITLE
D8NID-1205 ~ Adding Twig VarDumper to make it easier to debug templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -158,6 +158,7 @@
         "drupal/permissions_filter": "^1.1",
         "drupal/restui": "^1.17",
         "drupal/stage_file_proxy": "^1.0@beta",
+        "drupal/twig_vardumper": "^2.2",
         "drupal/upgrade_status": "^3.0",
         "kint-php/kint": "^3.3",
         "mglaman/drupal-check": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f3bacd9be3d845e2702f23471dfc5b9",
+    "content-hash": "1dd785191a90a7fd63dcde7a561eb426",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -16439,6 +16439,58 @@
             "homepage": "https://www.drupal.org/project/stage_file_proxy",
             "support": {
                 "source": "https://git.drupalcode.org/project/stage_file_proxy"
+            }
+        },
+        {
+            "name": "drupal/twig_vardumper",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/twig_vardumper.git",
+                "reference": "8.x-2.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/twig_vardumper-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "2b42f2a88fe9731edf0e055745b981ca20e32678"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "symfony/var-dumper": "~4.2|~5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.2",
+                    "datestamp": "1591885101",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Egiguren a.k.a keopx",
+                    "homepage": "https://www.drupal.org/user/377362",
+                    "email": "keopx@keopx.net"
+                }
+            ],
+            "description": "Twig vardumper provides a better dump() and vardumper() function that can help you debug Twig variables.",
+            "homepage": "https://www.drupal.org/project/twig_vardumper",
+            "keywords": [
+                "Development",
+                "Drupal",
+                "Twig"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/twig_vardumper",
+                "issues": "https://www.drupal.org/project/issues/twig_vardumper"
             }
         },
         {


### PR DESCRIPTION
Adding this module as it's been a PITA to debug twig now that Kint isn't a sub-module to Devel. I ran into the old issue that any {{ kint() }} inserted into a template would result in the site redirecting to install.php. Prior to the Devel update you could get around this by requiring the module in settings.php and then calling Kint::$maxLevels = 3; but this doesn't work anymore.