### PR TITLE
Updated general webform config

### DIFF
--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -1,27 +1,15 @@
 settings:
+  default_page_base_path: /form
   default_status: open
-  default_page_base_path: form
-  default_ajax: false
-  default_ajax_effect: fade
-  default_ajax_speed: 500
-  default_ajax_progress_type: throbber
   default_form_open_message: 'This form has not yet been opened to submissions.'
-  default_form_close_message: 'Sorry… This form is closed to new submissions.'
+  default_form_close_message: 'Sorry&hellip; This form is closed to new submissions.'
   default_form_exception_message: 'Unable to display this webform. Please contact the site administrator.'
-  default_submit_button_label: Submit
-  default_reset_button_label: Reset
-  default_form_submit_once: false
   default_form_confidential_message: 'This form is confidential. You must <a href="[site:login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.'
   default_form_access_denied_message: 'Please login to access this form.'
-  default_form_disable_back: false
-  default_form_submit_back: false
-  default_form_unsaved: false
-  default_form_novalidate: false
-  default_form_disable_inline_errors: false
-  default_form_required: false
   default_form_required_label: 'Indicates required field'
-  default_form_details_toggle: true
-  default_form_file_limit: ''
+  default_submit_button_label: Submit
+  default_reset_button_label: Reset
+  default_delete_button_label: Delete
   form_classes: |
     container-inline clearfix
     form--inline clearfix
@@ -29,22 +17,60 @@ settings:
     messages messages--warning
     messages messages--status
   button_classes: ''
+  default_form_submit_once: false
+  default_form_disable_back: false
+  default_form_submit_back: false
+  default_form_unsaved: false
+  default_form_novalidate: false
+  default_form_disable_inline_errors: false
+  default_form_required: false
+  default_form_details_toggle: true
   default_wizard_prev_button_label: 'Previous Page'
   default_wizard_next_button_label: 'Next Page'
   default_wizard_start_label: Start
   default_wizard_confirmation_label: Complete
+  default_wizard_toggle_show_label: 'Show all'
+  default_wizard_toggle_hide_label: 'Hide all'
   default_preview_next_button_label: Preview
   default_preview_prev_button_label: '< Previous'
   default_preview_label: Preview
   default_preview_title: '[webform:title]: Preview'
-  default_preview_message: 'Please review your submission. Your submission is not complete until you press the "Submit" button!'
+  default_preview_message: 'Please review your submission. Your submission is not complete until you press the &quot;Submit&quot; button!'
+  preview_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  default_confirmation_message: 'New submission added to [webform:title].'
+  default_confirmation_back_label: 'Back to form'
+  confirmation_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  confirmation_back_classes: button
+  default_share: false
+  default_share_node: false
+  default_share_theme_name: ''
+  default_ajax: false
+  default_ajax_progress_type: throbber
+  default_ajax_effect: fade
+  default_ajax_speed: 500
+  dialog_options:
+    narrow:
+      title: Narrow
+      width: 600
+    normal:
+      title: Normal
+      width: 800
+    wide:
+      title: Wide
+      width: 1000
+  dialog: false
+  default_form_file_limit: ''
   default_draft_button_label: 'Save Draft'
   default_draft_saved_message: 'Submission saved. You may return to this form later and it will restore the current values.'
   default_draft_loaded_message: 'A partially-completed form was found. Please complete the remaining portions.'
   default_draft_pending_single_message: 'You have a pending draft for this webform. <a href="#">Load your pending draft</a>.'
   default_draft_pending_multiple_message: 'You have pending drafts for this webform. <a href="#">View your pending drafts</a>.'
-  default_confirmation_message: 'New submission added to [webform:title].'
-  default_confirmation_back_label: 'Back to form'
   default_submission_label: '[webform_submission:submitted-to]: Submission #[webform_submission:serial]'
   default_submission_access_denied_message: 'Please login to access this submission.'
   default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
@@ -66,28 +92,8 @@ settings:
   default_previous_submission_message: 'You have already submitted this webform. <a href="#">View your previous submission</a>.'
   default_previous_submissions_message: 'You have already submitted this webform. <a href="#">View your previous submissions</a>.'
   default_autofill_message: 'This submission has been autofilled with your previous submission.'
-  preview_classes: |
-    messages messages--error
-    messages messages--warning
-    messages messages--status
-  confirmation_classes: |
-    messages messages--error
-    messages messages--warning
-    messages messages--status
-  confirmation_back_classes: button
   default_limit_total_message: 'No more submissions are permitted.'
   default_limit_user_message: 'No more submissions are permitted.'
-  dialog: false
-  dialog_options:
-    narrow:
-      title: Narrow
-      width: 600
-    normal:
-      title: Normal
-      width: 800
-    wide:
-      title: Wide
-      width: 1000
 assets:
   css: ''
   javascript: ''
@@ -302,7 +308,9 @@ requirements:
   spam: true
 langcode: en
 third_party_settings:
-  captcha:
-    replace_administration_mode: true
+  honeypot: {  }
 _core:
   default_config_hash: t12uM9LsMxrSJGW2ihnFm2wF9fXmUAv9iMMPIDu_yow
+form:
+  filter_category: ''
+  filter_state: ''


### PR DESCRIPTION
Filled in the gaps based on vanilla webform config. 

NB: recommend redirect id 39129 is deleted (`form/contact-the-make-the-call-team`) as otherwise saving/importing config can clash with a redirect that covers that path.