### PR TITLE
Minor config to contacts solr search mode

### DIFF
--- a/config/sync/views.view.contacts.yml
+++ b/config/sync/views.view.contacts.yml
@@ -195,8 +195,8 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          parse_mode: edismax
-          min_length: null
+          parse_mode: terms
+          min_length: 2
           fields:
             - body
             - field_supplementary_contact


### PR DESCRIPTION
Allows closer matches to D7 equivalent.

Related: https://github.com/dof-dss/nidirect-site-modules/pull/387