### PR TITLE
New image styles and view modes

### DIFF
--- a/config/sync/core.entity_view_display.media.image.article_float.yml
+++ b/config/sync/core.entity_view_display.media.image.article_float.yml
@@ -1,13 +1,13 @@
-uuid: 3bd94fef-6639-4034-a094-cab33055ef5c
+uuid: 0c4e0908-cbe1-448a-a7a5-9185bc7b66ee
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.media.article_full
+    - core.entity_view_mode.media.article_float
     - field.field.media.image.field_caption
     - field.field.media.image.field_media_image
     - media.type.image
-    - responsive_image.styles.inline_xl
+    - responsive_image.styles.inline
   module:
     - layout_builder
     - responsive_image
@@ -17,15 +17,15 @@ third_party_settings:
     enabled: false
 _core:
   default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
-id: media.image.article_full
+id: media.image.article_float
 targetEntityType: media
 bundle: image
-mode: article_full
+mode: article_float
 content:
   field_media_image:
     label: visually_hidden
     settings:
-      responsive_image_style: inline_xl
+      responsive_image_style: inline
       image_link: ''
     third_party_settings: {  }
     type: responsive_image

--- a/config/sync/core.entity_view_display.media.image.article_float_expandable.yml
+++ b/config/sync/core.entity_view_display.media.image.article_float_expandable.yml
@@ -1,13 +1,13 @@
-uuid: 3bd94fef-6639-4034-a094-cab33055ef5c
+uuid: 917dc9fd-458c-4de9-83f3-cb4a7361d83a
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.media.article_full
+    - core.entity_view_mode.media.article_float_expandable
     - field.field.media.image.field_caption
     - field.field.media.image.field_media_image
     - media.type.image
-    - responsive_image.styles.inline_xl
+    - responsive_image.styles.inline_expandable
   module:
     - layout_builder
     - responsive_image
@@ -17,15 +17,15 @@ third_party_settings:
     enabled: false
 _core:
   default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
-id: media.image.article_full
+id: media.image.article_float_expandable
 targetEntityType: media
 bundle: image
-mode: article_full
+mode: article_float_expandable
 content:
   field_media_image:
     label: visually_hidden
     settings:
-      responsive_image_style: inline_xl
+      responsive_image_style: inline_expandable
       image_link: ''
     third_party_settings: {  }
     type: responsive_image

--- a/config/sync/core.entity_view_display.media.image.article_full_expandable.yml
+++ b/config/sync/core.entity_view_display.media.image.article_full_expandable.yml
@@ -1,13 +1,13 @@
-uuid: 3bd94fef-6639-4034-a094-cab33055ef5c
+uuid: 0c11ff69-d8ee-41e8-8b58-89261e76aa9d
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.media.article_full
+    - core.entity_view_mode.media.article_full_expandable
     - field.field.media.image.field_caption
     - field.field.media.image.field_media_image
     - media.type.image
-    - responsive_image.styles.inline_xl
+    - responsive_image.styles.inline_xl_expandable
   module:
     - layout_builder
     - responsive_image
@@ -17,15 +17,15 @@ third_party_settings:
     enabled: false
 _core:
   default_config_hash: jOwnt_yq6AKAfqU6f0xKnxEkFQ2eTPJWxrk3WMLbL68
-id: media.image.article_full
+id: media.image.article_full_expandable
 targetEntityType: media
 bundle: image
-mode: article_full
+mode: article_full_expandable
 content:
   field_media_image:
     label: visually_hidden
     settings:
-      responsive_image_style: inline_xl
+      responsive_image_style: inline_xl_expandable
       image_link: ''
     third_party_settings: {  }
     type: responsive_image

--- a/config/sync/core.entity_view_mode.media.article_float.yml
+++ b/config/sync/core.entity_view_mode.media.article_float.yml
@@ -1,0 +1,10 @@
+uuid: ea7c0051-64eb-4507-aa91-f972d5166b04
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.article_float
+label: 'Article float'
+targetEntityType: media
+cache: true

--- a/config/sync/core.entity_view_mode.media.article_float_expandable.yml
+++ b/config/sync/core.entity_view_mode.media.article_float_expandable.yml
@@ -1,0 +1,10 @@
+uuid: 2ccfbe94-731f-4bae-83e6-a060961b8f56
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.article_float_expandable
+label: 'Article float expandable'
+targetEntityType: media
+cache: true

--- a/config/sync/core.entity_view_mode.media.article_full_expandable.yml
+++ b/config/sync/core.entity_view_mode.media.article_full_expandable.yml
@@ -1,0 +1,10 @@
+uuid: 1c4ddf2f-f22d-4dfc-b90c-2118e18f8095
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.article_full_expandable
+label: 'Article full expandable'
+targetEntityType: media
+cache: true

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -3,14 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.article_float
+    - core.entity_view_mode.media.article_float_expandable
     - core.entity_view_mode.media.article_full
-    - core.entity_view_mode.media.landscape_float
-    - core.entity_view_mode.media.landscape_float_xp
-    - core.entity_view_mode.media.landscape_full
-    - core.entity_view_mode.media.landscape_full_xp
-    - core.entity_view_mode.media.portrait_float
-    - core.entity_view_mode.media.portrait_float_xp
-    - core.entity_view_mode.media.portrait_full
+    - core.entity_view_mode.media.article_full_expandable
   module:
     - cookie_content_blocker
     - editor
@@ -117,13 +113,10 @@ filters:
         remote_video: remote_video
         video: video
       allowed_view_modes:
-        landscape_float: landscape_float
-        landscape_float_xp: landscape_float_xp
-        landscape_full: landscape_full
-        landscape_full_xp: landscape_full_xp
-        portrait_float: portrait_float
-        portrait_float_xp: portrait_float_xp
-        portrait_full: portrait_full
+        article_float: article_float
+        article_float_expandable: article_float_expandable
+        article_full: article_full
+        article_full_expandable: article_full_expandable
   google_analytics_counter_filter:
     id: google_analytics_counter_filter
     provider: google_analytics_counter

--- a/config/sync/filter.format.full_html.yml
+++ b/config/sync/filter.format.full_html.yml
@@ -3,7 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.article_float
+    - core.entity_view_mode.media.article_float_expandable
     - core.entity_view_mode.media.article_full
+    - core.entity_view_mode.media.article_full_expandable
     - core.entity_view_mode.media.banner_deep
     - core.entity_view_mode.media.banner_thin
     - core.entity_view_mode.media.card_large
@@ -125,7 +128,10 @@ filters:
         remote_video: remote_video
         video: video
       allowed_view_modes:
+        article_float: article_float
+        article_float_expandable: article_float_expandable
         article_full: article_full
+        article_full_expandable: article_full_expandable
         banner_deep: banner_deep
         banner_thin: banner_thin
         card_large: card_large

--- a/config/sync/image.style.nigov_float_x1.yml
+++ b/config/sync/image.style.nigov_float_x1.yml
@@ -1,0 +1,15 @@
+uuid: 2884e23b-f90f-4916-bd85-e7a667e1e717
+langcode: en
+status: true
+dependencies: {  }
+name: nigov_float_x1
+label: 'nigov float (x1)'
+effects:
+  8d8e96ea-3378-42fa-a1c0-1e42ed91f3d6:
+    uuid: 8d8e96ea-3378-42fa-a1c0-1e42ed91f3d6
+    id: image_scale
+    weight: 1
+    data:
+      width: 300
+      height: null
+      upscale: true

--- a/config/sync/image.style.nigov_float_x2.yml
+++ b/config/sync/image.style.nigov_float_x2.yml
@@ -1,0 +1,15 @@
+uuid: eb55b1cb-6f0f-4f7a-8a2b-38035a7fb5e6
+langcode: en
+status: true
+dependencies: {  }
+name: nigov_float_x2
+label: 'nigov float (x2)'
+effects:
+  1a7398ef-fe55-4466-859c-6cc91d605fd5:
+    uuid: 1a7398ef-fe55-4466-859c-6cc91d605fd5
+    id: image_scale
+    weight: 1
+    data:
+      width: 600
+      height: null
+      upscale: true

--- a/config/sync/responsive_image.styles.inline.yml
+++ b/config/sync/responsive_image.styles.inline.yml
@@ -3,18 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.nigov_landscape_1240x826_x2
-    - image.style.nigov_landscape_300x200_x1
-    - image.style.nigov_landscape_450x300_x1
-    - image.style.nigov_landscape_600x400_x2
-    - image.style.nigov_landscape_620x413_x1
-    - image.style.nigov_landscape_900x600_x2
-    - image.style.nigov_landscape_thumbnail_150x100_x1
-    - image.style.nigov_landscape_thumbnail_300x200_x2
-    - image.style.nigov_landscape_xxl_1920x1280_x2
-    - image.style.nigov_landscape_xxl_960x640_x1
+    - image.style.nigov_float_x1
+    - image.style.nigov_float_x2
+    - image.style.nigov_full_1240_x2
+    - image.style.nigov_full_450_x1
+    - image.style.nigov_full_620_x1
+    - image.style.nigov_full_900_x2
 id: inline
-label: 'Landscape float'
+label: 'Inline float'
 image_style_mappings:
   -
     breakpoint_id: responsive_image.viewport_sizing
@@ -23,15 +19,11 @@ image_style_mappings:
     image_mapping:
       sizes: 100vw
       sizes_image_styles:
-        - nigov_landscape_1240x826_x2
-        - nigov_landscape_300x200_x1
-        - nigov_landscape_450x300_x1
-        - nigov_landscape_600x400_x2
-        - nigov_landscape_620x413_x1
-        - nigov_landscape_900x600_x2
-        - nigov_landscape_thumbnail_150x100_x1
-        - nigov_landscape_thumbnail_300x200_x2
-        - nigov_landscape_xxl_1920x1280_x2
-        - nigov_landscape_xxl_960x640_x1
+        - nigov_float_x1
+        - nigov_float_x2
+        - nigov_full_1240_x2
+        - nigov_full_450_x1
+        - nigov_full_620_x1
+        - nigov_full_900_x2
 breakpoint_group: responsive_image
-fallback_image_style: nigov_landscape_300x200_x1
+fallback_image_style: nigov_float_x1

--- a/config/sync/responsive_image.styles.inline_expandable.yml
+++ b/config/sync/responsive_image.styles.inline_expandable.yml
@@ -3,12 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.nigov_landscape_1240x826_x2
-    - image.style.nigov_landscape_450x300_x1
-    - image.style.nigov_landscape_620x413_x1
-    - image.style.nigov_landscape_900x600_x2
+    - image.style.nigov_full_1240_x2
+    - image.style.nigov_full_450_x1
+    - image.style.nigov_full_620_x1
+    - image.style.nigov_full_900_x2
 id: inline_expandable
-label: 'Landscape float expandable'
+label: 'Inline float expandable'
 image_style_mappings:
   -
     breakpoint_id: responsive_image.viewport_sizing
@@ -17,9 +17,9 @@ image_style_mappings:
     image_mapping:
       sizes: 100vw
       sizes_image_styles:
-        - nigov_landscape_1240x826_x2
-        - nigov_landscape_450x300_x1
-        - nigov_landscape_620x413_x1
-        - nigov_landscape_900x600_x2
+        - nigov_full_1240_x2
+        - nigov_full_450_x1
+        - nigov_full_620_x1
+        - nigov_full_900_x2
 breakpoint_group: responsive_image
-fallback_image_style: nigov_landscape_620x413_x1
+fallback_image_style: nigov_full_620_x1

--- a/config/sync/responsive_image.styles.inline_xl.yml
+++ b/config/sync/responsive_image.styles.inline_xl.yml
@@ -3,12 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.nigov_landscape_1240x826_x2
-    - image.style.nigov_landscape_450x300_x1
-    - image.style.nigov_landscape_620x413_x1
-    - image.style.nigov_landscape_900x600_x2
+    - image.style.nigov_full_1240_x2
+    - image.style.nigov_full_450_x1
+    - image.style.nigov_full_620_x1
+    - image.style.nigov_full_900_x2
 id: inline_xl
-label: 'Landscape full width'
+label: 'Inline full width'
 image_style_mappings:
   -
     breakpoint_id: responsive_image.viewport_sizing
@@ -17,9 +17,9 @@ image_style_mappings:
     image_mapping:
       sizes: 100vw
       sizes_image_styles:
-        - nigov_landscape_1240x826_x2
-        - nigov_landscape_450x300_x1
-        - nigov_landscape_620x413_x1
-        - nigov_landscape_900x600_x2
+        - nigov_full_1240_x2
+        - nigov_full_450_x1
+        - nigov_full_620_x1
+        - nigov_full_900_x2
 breakpoint_group: responsive_image
-fallback_image_style: nigov_landscape_620x413_x1
+fallback_image_style: nigov_full_620_x1

--- a/config/sync/responsive_image.styles.inline_xl_expandable.yml
+++ b/config/sync/responsive_image.styles.inline_xl_expandable.yml
@@ -3,14 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.nigov_landscape_1240x826_x2
-    - image.style.nigov_landscape_450x300_x1
-    - image.style.nigov_landscape_620x413_x1
-    - image.style.nigov_landscape_900x600_x2
-    - image.style.nigov_landscape_xxl_1920x1280_x2
-    - image.style.nigov_landscape_xxl_960x640_x1
+    - image.style.nigov_full_1240_x2
+    - image.style.nigov_full_1880_x2
+    - image.style.nigov_full_450_x1
+    - image.style.nigov_full_620_x1
+    - image.style.nigov_full_900_x2
+    - image.style.nigov_full_940_x1
 id: inline_xl_expandable
-label: 'Landscape full width expandable'
+label: 'Inline full width expandable'
 image_style_mappings:
   -
     breakpoint_id: responsive_image.viewport_sizing
@@ -19,11 +19,11 @@ image_style_mappings:
     image_mapping:
       sizes: 100vw
       sizes_image_styles:
-        - nigov_landscape_1240x826_x2
-        - nigov_landscape_450x300_x1
-        - nigov_landscape_620x413_x1
-        - nigov_landscape_900x600_x2
-        - nigov_landscape_xxl_1920x1280_x2
-        - nigov_landscape_xxl_960x640_x1
+        - nigov_full_1240_x2
+        - nigov_full_1880_x2
+        - nigov_full_450_x1
+        - nigov_full_620_x1
+        - nigov_full_900_x2
+        - nigov_full_940_x1
 breakpoint_group: responsive_image
-fallback_image_style: nigov_landscape_xxl_960x640_x1
+fallback_image_style: nigov_full_940_x1


### PR DESCRIPTION
… and adjustments to basic_html text format to enable them and disable others.

In D7, the image styles available in CKEditor constrained image width only.  In D8, the corresponding styles constrain both width and height - and these present problems migrating from D7 to D8.

The changes in this PR are needed to better align with images styles migrating from D7. The changes will mean images embedded in article content will only have fixed widths - image height will not be fixed or cropped.  And the list of available image view modes that editors will see in ckeditor is reduced to just 4:

Article float (resp img mapping: inline)
Article float expandable (resp img mapping: inline_expandable)
Article full (resp img mapping: inline_xl)
Article full expandable (resp img mapping: inline_xl_expandable)

There will be no need for the various landscape and portrait view modes that were previously available to editors in the basic_html text format and they have been removed. They are still available in the full_html text format.

