### PR TITLE
footer text (field_additional_info)

### DIFF
--- a/config/sync/core.entity_form_display.node.embargoed_publication.default.yml
+++ b/config/sync/core.entity_form_display.node.embargoed_publication.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.embargoed_publication.body
+    - field.field.node.embargoed_publication.field_additional_info
     - field.field.node.embargoed_publication.field_meta_tags
     - field.field.node.embargoed_publication.field_publication_type
     - field.field.node.embargoed_publication.field_published_date
@@ -13,6 +14,7 @@ dependencies:
     - field.field.node.embargoed_publication.field_summary
     - field.field.node.embargoed_publication.field_top_level_theme
     - node.type.embargoed_publication
+    - workflows.workflow.nics_editorial_workflow
   module:
     - content_moderation
     - datetime
@@ -105,7 +107,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 22
+    weight: 17
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -189,4 +191,5 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_additional_info: true
   field_top_level_theme: true

--- a/config/sync/core.entity_form_display.node.publication.default.yml
+++ b/config/sync/core.entity_form_display.node.publication.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.publication.body
+    - field.field.node.publication.field_additional_info
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
@@ -13,6 +14,7 @@ dependencies:
     - field.field.node.publication.field_summary
     - field.field.node.publication.field_top_level_theme
     - node.type.publication
+    - workflows.workflow.nics_editorial_workflow
   module:
     - content_moderation
     - datetime
@@ -39,7 +41,7 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -101,9 +103,9 @@ content:
     region: content
   flag:
     weight: 10
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   langcode:
     type: language_select
     weight: 2
@@ -113,13 +115,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 20
+    weight: 18
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -127,7 +129,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 12
+    weight: 13
     region: content
     third_party_settings: {  }
   publish_on:
@@ -151,14 +153,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 16
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 13
+    weight: 14
     region: content
     third_party_settings: {  }
   title:
@@ -171,7 +173,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 10
+    weight: 11
     settings:
       match_operator: CONTAINS
       size: 60
@@ -192,9 +194,10 @@ content:
     type: options_select
     region: content
   url_redirects:
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_additional_info: true
   field_top_level_theme: true

--- a/config/sync/core.entity_view_display.node.embargoed_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.embargoed_publication.body
+    - field.field.node.embargoed_publication.field_additional_info
     - field.field.node.embargoed_publication.field_meta_tags
     - field.field.node.embargoed_publication.field_publication_type
     - field.field.node.embargoed_publication.field_published_date
@@ -32,6 +33,13 @@ content:
     weight: 4
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_additional_info:
+    weight: 10
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
     region: content
   field_meta_tags:
     weight: 8

--- a/config/sync/core.entity_view_display.node.embargoed_publication.diff.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.diff.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.diff
     - field.field.node.embargoed_publication.body
+    - field.field.node.embargoed_publication.field_additional_info
     - field.field.node.embargoed_publication.field_meta_tags
     - field.field.node.embargoed_publication.field_publication_type
     - field.field.node.embargoed_publication.field_published_date
@@ -17,9 +18,12 @@ dependencies:
   module:
     - datetime
     - field_group
+    - file
     - layout_builder
     - metatag
+    - nidirect_common
     - options
+    - smart_trim
     - text
     - user
 third_party_settings:
@@ -34,7 +38,7 @@ third_party_settings:
         - field_publication_type
         - field_meta_tags
       parent_name: ''
-      weight: 6
+      weight: 7
       format_type: html_element
       region: content
       format_settings:
@@ -65,6 +69,15 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_additional_info:
+    type: ancestral_value_field_formatter
+    weight: 5
+    region: content
+    label: hidden
+    settings:
+      ancestor_depth: '2'
+      ancestors_only: false
+    third_party_settings: {  }
   field_meta_tags:
     weight: 10
     label: inline
@@ -88,6 +101,14 @@ content:
       format_type: medium
       timezone_override: ''
     third_party_settings: {  }
+  field_secure_attachment:
+    type: file_default
+    weight: 4
+    region: content
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
   field_site_themes:
     type: entity_reference_label
     weight: 8
@@ -107,17 +128,26 @@ content:
   field_summary:
     weight: 2
     label: hidden
-    settings: {  }
+    settings:
+      trim_length: 600
+      trim_type: chars
+      trim_suffix: ''
+      wrap_output: false
+      wrap_class: trimmed
+      more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: full
+      trim_options: {  }
     third_party_settings: {  }
-    type: text_default
+    type: smart_trim
     region: content
   links:
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_secure_attachment: true
   field_top_level_theme: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.embargoed_publication.full.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.embargoed_publication.body
+    - field.field.node.embargoed_publication.field_additional_info
     - field.field.node.embargoed_publication.field_meta_tags
     - field.field.node.embargoed_publication.field_publication_type
     - field.field.node.embargoed_publication.field_published_date
@@ -18,6 +19,7 @@ dependencies:
     - datetime
     - file
     - layout_builder
+    - nidirect_common
     - smart_trim
     - text
     - user
@@ -37,6 +39,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_additional_info:
+    type: ancestral_value_field_formatter
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      ancestor_depth: '2'
+      ancestors_only: false
+    third_party_settings: {  }
   field_published_date:
     type: datetime_default
     weight: 0

--- a/config/sync/core.entity_view_display.node.embargoed_publication.search_result.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.embargoed_publication.body
+    - field.field.node.embargoed_publication.field_additional_info
     - field.field.node.embargoed_publication.field_meta_tags
     - field.field.node.embargoed_publication.field_publication_type
     - field.field.node.embargoed_publication.field_published_date
@@ -47,6 +48,7 @@ content:
 hidden:
   body: true
   content_moderation_control: true
+  field_additional_info: true
   field_meta_tags: true
   field_secure_attachment: true
   field_site_themes: true

--- a/config/sync/core.entity_view_display.node.embargoed_publication.teaser.yml
+++ b/config/sync/core.entity_view_display.node.embargoed_publication.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.embargoed_publication.body
+    - field.field.node.embargoed_publication.field_additional_info
     - field.field.node.embargoed_publication.field_meta_tags
     - field.field.node.embargoed_publication.field_publication_type
     - field.field.node.embargoed_publication.field_published_date
@@ -37,6 +38,7 @@ content:
     third_party_settings: {  }
 hidden:
   content_moderation_control: true
+  field_additional_info: true
   field_meta_tags: true
   field_publication_type: true
   field_published_date: true

--- a/config/sync/core.entity_view_display.node.publication.default.yml
+++ b/config/sync/core.entity_view_display.node.publication.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.publication.body
+    - field.field.node.publication.field_additional_info
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
@@ -36,6 +37,13 @@ content:
     weight: 5
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_additional_info:
+    weight: 11
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
     region: content
   field_attachment:
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.node.publication.diff.yml
+++ b/config/sync/core.entity_view_display.node.publication.diff.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.diff
     - field.field.node.publication.body
+    - field.field.node.publication.field_additional_info
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
@@ -19,7 +20,9 @@ dependencies:
     - field_group
     - layout_builder
     - metatag
+    - nidirect_common
     - options
+    - smart_trim
     - text
     - user
 third_party_settings:
@@ -34,7 +37,7 @@ third_party_settings:
         - field_publication_type
         - field_meta_tags
       parent_name: ''
-      weight: 8
+      weight: 7
       format_type: html_element
       region: content
       format_settings:
@@ -61,7 +64,7 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 5
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -70,9 +73,18 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_additional_info:
+    type: ancestral_value_field_formatter
+    weight: 5
+    region: content
+    label: above
+    settings:
+      ancestor_depth: '2'
+      ancestors_only: false
+    third_party_settings: {  }
   field_attachment:
     type: entity_reference_entity_view
-    weight: 6
+    weight: 4
     label: inline
     settings:
       view_mode: default
@@ -95,7 +107,7 @@ content:
     third_party_settings: {  }
   field_published_date:
     type: datetime_default
-    weight: 3
+    weight: 1
     region: content
     label: inline
     settings:
@@ -119,14 +131,24 @@ content:
       link: true
     third_party_settings: {  }
   field_summary:
-    weight: 4
+    weight: 2
     label: hidden
-    settings: {  }
+    settings:
+      trim_length: 600
+      trim_type: chars
+      trim_suffix: ''
+      wrap_output: false
+      wrap_class: trimmed
+      more_link: false
+      more_class: more-link
+      more_text: More
+      summary_handler: full
+      trim_options: {  }
     third_party_settings: {  }
-    type: text_default
+    type: smart_trim
     region: content
   links:
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.publication.full.yml
+++ b/config/sync/core.entity_view_display.node.publication.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.publication.body
+    - field.field.node.publication.field_additional_info
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
@@ -17,6 +18,7 @@ dependencies:
   module:
     - datetime
     - layout_builder
+    - nidirect_common
     - text
     - user
 third_party_settings:
@@ -35,6 +37,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_additional_info:
+    type: ancestral_value_field_formatter
+    weight: 4
+    region: content
+    label: visually_hidden
+    settings:
+      ancestor_depth: '2'
+      ancestors_only: 0
+    third_party_settings: {  }
   field_attachment:
     type: entity_reference_entity_view
     weight: 3

--- a/config/sync/core.entity_view_display.node.publication.search_result.yml
+++ b/config/sync/core.entity_view_display.node.publication.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.publication.body
+    - field.field.node.publication.field_additional_info
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
@@ -48,6 +49,7 @@ hidden:
   banner_display: true
   body: true
   content_moderation_control: true
+  field_additional_info: true
   field_attachment: true
   field_meta_tags: true
   field_site_themes: true

--- a/config/sync/core.entity_view_display.node.publication.teaser.yml
+++ b/config/sync/core.entity_view_display.node.publication.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.publication.body
+    - field.field.node.publication.field_additional_info
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
@@ -42,6 +43,7 @@ content:
     third_party_settings: {  }
 hidden:
   content_moderation_control: true
+  field_additional_info: true
   field_attachment: true
   field_meta_tags: true
   field_publication_type: true

--- a/config/sync/core.entity_view_display.taxonomy_term.site_themes.full.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.site_themes.full.yml
@@ -17,6 +17,7 @@ dependencies:
     - taxonomy.vocabulary.site_themes
   module:
     - layout_builder
+    - nidirect_common
     - text
 third_party_settings:
   layout_builder:
@@ -35,11 +36,13 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_additional_info:
-    type: text_default
+    type: ancestral_value_field_formatter
     weight: 2
     region: content
     label: hidden
-    settings: {  }
+    settings:
+      ancestor_depth: '2'
+      ancestors_only: 0
     third_party_settings: {  }
   field_theme_summary:
     weight: 0

--- a/config/sync/field.field.node.embargoed_publication.field_additional_info.yml
+++ b/config/sync/field.field.node.embargoed_publication.field_additional_info.yml
@@ -1,0 +1,21 @@
+uuid: 2c2a9c08-119a-472c-b7c2-b5314e8ae817
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_additional_info
+    - node.type.embargoed_publication
+  module:
+    - text
+id: node.embargoed_publication.field_additional_info
+field_name: field_additional_info
+entity_type: node
+bundle: embargoed_publication
+label: 'Footer text'
+description: 'Optional footer text displayed at the bottom of the publication. This will replace any footer text set in the parent theme/subtheme.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.node.publication.field_additional_info.yml
+++ b/config/sync/field.field.node.publication.field_additional_info.yml
@@ -1,0 +1,21 @@
+uuid: c2b7ee6e-3eac-4f76-a4f8-4f4c0f2bdb1f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_additional_info
+    - node.type.publication
+  module:
+    - text
+id: node.publication.field_additional_info
+field_name: field_additional_info
+entity_type: node
+bundle: publication
+label: 'Footer text'
+description: 'Optional footer text displayed at the bottom of the publication. This will replace any footer text set in the parent theme/subtheme.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long


### PR DESCRIPTION
Add footer text (field_additional_info) to publications content types.
Set footer text in full display to use ancestral value format on both themes and publications.