### PR TITLE
Set region id to eu

### DIFF
--- a/config/sync/geocoder.geocoder_provider.googlemaps.yml
+++ b/config/sync/geocoder.geocoder_provider.googlemaps.yml
@@ -8,6 +8,7 @@ plugin: googlemaps
 configuration:
   region: 'gb, ie'
   apiKey: '<placeholder>'
+  region: eu
   throttle:
     period: null
     limit: null


### PR DESCRIPTION
Allows geocoding of UK and IE addresses and postcodes. A blank region id yields 0 results and it's not possible to dynamically adjust the region config owing to the way the geocoding module and libraries interact with each other.

This handy adjustment allows google maps to look at a wider scope of region that includes both the UK and Ireland, but excludes some of the tricker/wackier matches you might get across in the US or wider afield in the world.

Details of region codes: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry