### PR TITLE
Catch-all routing redirect config

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -4,6 +4,12 @@
   upstream: "nidirect:http"
   cache:
     enabled: false
+  redirects:
+    paths:
+      '^(.*/)index\.php/(.*)':
+        to: https://{default}/$2
+        regexp: true
+        code: 301
 
 "https://www.{default}/":
   type: redirect


### PR DESCRIPTION
Should help address the rare instances where Drupal can generate a base URL of /index.php/pathname.