### PR TITLE
CSP refinements based on logged exceptions

### DIFF
--- a/config/sync/csp.settings.yml
+++ b/config/sync/csp.settings.yml
@@ -26,6 +26,7 @@ report-only:
         - 'https://www.google-analytics.com'
         - 'https://cdn.jsdelivr.net'
         - 'https://i.ytimg.com'
+        - 'https://www.gstatic.com'
         - 'https://maps.gstatic.com'
         - 'https://maps.googleapis.com'
         - 'data:'

--- a/config/sync/csp.settings.yml
+++ b/config/sync/csp.settings.yml
@@ -32,6 +32,8 @@ report-only:
         - 'https://maps.googleapis.com'
         - 'data:'
       base: self
+    manifest-src:
+      base: self
     script-src:
       sources:
         - 'https://www.googletagmanager.com'

--- a/config/sync/csp.settings.yml
+++ b/config/sync/csp.settings.yml
@@ -22,6 +22,7 @@ report-only:
       base: self
     img-src:
       sources:
+        - 'https://translate.google.com'
         - 'https://www.googletagmanager.com'
         - 'https://www.google-analytics.com'
         - 'https://cdn.jsdelivr.net'


### PR DESCRIPTION
A few extra things triggered by:

- Google translate service on articles.
- The site theme's manifest (in the `<head>` element), ie: `themes/custom/nicsdru_nidirect_theme/images/favicons/site.webmanifest`