### PR TITLE
Remove HTML regex from webform validation

### DIFF
--- a/config/sync/webform.webform.site_feedback.yml
+++ b/config/sync/webform.webform.site_feedback.yml
@@ -84,8 +84,6 @@ elements: |
         '#title': 'Provide details of technical problems or make a comment about the website'
         '#placeholder': 'Plain text only, 750 characters maximum.'
         '#required': true
-        '#pattern': '^(?!.*<[^>]+>).*'
-        '#pattern_error': 'HTML or markup is not permitted.'
         '#counter_type': character
         '#counter_minimum': 1
         '#counter_maximum': 750

--- a/config/sync/webform.webform.your_comments.yml
+++ b/config/sync/webform.webform.your_comments.yml
@@ -140,14 +140,12 @@ elements: |
     enter_your_feedback:
       '#type': textarea
       '#title': 'Enter your feedback'
-      '#description': 'Plain text only, 750 characters maximum.'
+      '#description': '750 characters maximum.'
       '#title_display': invisible
       '#description_display': before
       '#help_display': element_before
       '#required': true
       '#required_error': 'Please provide your feedback'
-      '#pattern': '^(?!.*<[^>]+>).*'
-      '#pattern_error': 'HTML or markup is not permitted.'
       '#counter_type': character
       '#counter_minimum': 1
       '#counter_maximum': 750
@@ -158,14 +156,12 @@ elements: |
     question_details:
       '#type': textarea
       '#title': 'Enter your question'
-      '#description': 'Plain text only, 750 characters maximum.'
+      '#description': '750 characters maximum.'
       '#title_display': invisible
       '#description_display': before
       '#help_display': element_before
       '#required': true
       '#required_error': 'Please enter your question'
-      '#pattern': '^(?!.*<[^>]+>).*'
-      '#pattern_error': 'HTML or markup is not permitted.'
       '#counter_type': character
       '#counter_minimum': 1
       '#counter_maximum': 750


### PR DESCRIPTION
HTML tags now stripped in nidirect_webforms.module, allows the benefits to be re-used across storage + any attached handlers.