### PR TITLE
D8NID-1227 enable MAS content import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,5 @@ console/
 .talismanrc
 
 # Ignore migration config
-!/config/sync/migrate_plus.migration.money_advice_service_rss_articles
 /config/sync/migrate_plus.*
+!/config/sync/migrate_plus.migration.money_advice_service_rss_articles

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ console/
 .talismanrc
 
 # Ignore migration config
+!/config/sync/migrate_plus.migration.money_advice_service_rss_articles
 /config/sync/migrate_plus.*

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ console/
 
 # Ignore migration config
 /config/sync/migrate_plus.*
-!/config/sync/migrate_plus.migration.money_advice_service_rss_articles
+!/config/sync/migrate_plus.migration.money_advice_service_rss_articles.yml

--- a/config/sync/migrate_plus.migration.money_advice_service_rss_articles.yml
+++ b/config/sync/migrate_plus.migration.money_advice_service_rss_articles.yml
@@ -1,0 +1,110 @@
+uuid: 6ac66ae9-b073-4365-ba89-82680f5e5351
+langcode: en
+status: true
+dependencies: {  }
+id: money_advice_service_rss_articles
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - nidirect
+migration_group: money_advice_service_rss
+label: 'Import Money Advice Service RSS feed'
+source:
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: xml
+  urls:
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/17.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/18.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/21.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/22.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/112.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/113.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/115.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/116.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/117.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/118.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/120.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/121.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/122.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/123.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/124.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/126.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/128.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/130.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/131.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/161.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/168.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/169.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/170.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/172.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/173.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/174.rss'
+    - 'https://webfeeds.moneyadviceservice.org.uk/feeds/175.rss'
+  item_selector: /rss/channel/item
+  fields:
+    -
+      name: guid
+      label: GUID
+      selector: guid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: pub_date
+      label: 'Publication date'
+      selector: pubDate
+    -
+      name: body
+      label: Body
+      selector: description
+  ids:
+    guid:
+      type: string
+process:
+  title:
+    -
+      plugin: get
+      source: title
+  body/format:
+    plugin: default_value
+    default_value: basic_html
+  body/value: body
+  created:
+    -
+      plugin: format_date
+      from_format: 'D, d M Y H:i:s O'
+      to_format: U
+      source: pub_date
+  published:
+    -
+      plugin: default_value
+      default_value: 1
+  field_summary:
+    -
+      plugin: callback
+      callable:
+        - \Drupal\nidirect_money_advice_articles\ArticleProcessors
+        - summary
+      source: body
+  field_teaser:
+    -
+      plugin: callback
+      callable:
+        - \Drupal\nidirect_money_advice_articles\ArticleProcessors
+        - teaser
+      source: body
+  field_subtheme:
+    -
+      plugin: callback
+      callable:
+        - \Drupal\nidirect_money_advice_articles\ArticleProcessors
+        - subtheme
+      source: body
+destination:
+  plugin: 'entity:node'
+  default_bundle: article
+migration_dependencies:
+  required: {  }

--- a/config/sync/ultimate_cron.job.money_advice_articles.yml
+++ b/config/sync/ultimate_cron.job.money_advice_articles.yml
@@ -1,6 +1,6 @@
 uuid: 46f892fc-88d6-4381-8896-6beab8697a6d
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - nidirect_money_advice_articles


### PR DESCRIPTION
* Adds an exception to gitignore to let us house the migration config for MAS content. Without that, we would need to reinstall the module each time we want to make changes to the active migration config (it's copied into active state from config/install on module installation).
* Turns on the cron task handler.

**NB: MAS module should be uninstalled before this config goes in. Otherwise it'll grumble about existing config being present.**