### PR TITLE
Popular info menu fix

### DIFF
--- a/config/sync/views.view.popular_content.yml
+++ b/config/sync/views.view.popular_content.yml
@@ -63,11 +63,11 @@ display:
         type: html_list
         options:
           grouping: {  }
-          row_class: ''
+          row_class: nav-item
           default_row_class: false
           type: ul
           wrapper_class: ''
-          class: ''
+          class: nav-menu
       row:
         type: fields
         options:
@@ -893,11 +893,29 @@ display:
       defaults:
         filters: false
         filter_groups: false
+        style: false
+        row: false
       filter_groups:
         operator: AND
         groups:
           1: AND
           2: OR
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: false
+          type: ul
+          wrapper_class: ''
+          class: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Fixes styling issue with popular content menus by removal of nav-menu and nav-item classes.  Classes added back in for most popular content blocks - all except the popular conditions block on the illnesses and conditions page.