### PR TITLE
Feedback forms fixes:

### DIFF
--- a/config/sync/webform.webform.site_feedback.yml
+++ b/config/sync/webform.webform.site_feedback.yml
@@ -20,11 +20,11 @@ elements: |
       '#type': processed_text
       '#text': |
         <p class="nodeSummary">nidirect is the government information and services website for people living in Northern Ireland.</p>
-        
+
         <h2>Before you start</h2>
-        
+
         <p>If you are living in Scotland, England or Wales please visit the <a href="https://www.gov.uk/contact/govuk" rel="nofollow" target="_blank" title="external link opens in a new window / tab">GOV.UK website</a>.</p>
-        
+
         <div class="info-notice">
         <ul>
         	<li>only use this form to provide feedback about the nidirect website</li>
@@ -33,7 +33,7 @@ elements: |
         	<li>the nidirect <a href="/articles/nidirect-web-service-privacy-notice">privacy notice</a> applies to any information you send on this feedback&nbsp;form</li>
         </ul>
         </div>
-        
+
       '#format': full_html
   page_feedback:
     '#type': webform_wizard_page
@@ -117,9 +117,9 @@ elements: |
             value: angling
       '#text': |
         <h2>What to do next</h2>
-        
+
         <p>Comments or queries about angling can be emailed to <a href="mailto:anglingcorrespondence@daera-ni.gov.uk ">anglingcorrespondence@daera-ni.gov.uk&nbsp;</a></p>
-        
+
       '#format': full_html
     benefits:
       '#type': processed_text
@@ -129,40 +129,40 @@ elements: |
             value: benefits
       '#text': |
         <h2>What to do next</h2>
-        
+
         <p>If you have a comment or query about benefits, you will need to contact the government department&nbsp;or&nbsp;agency which handles that benefit.&nbsp; Contacts for common benefits are listed below.</p>
-        
+
         <h3>Carer's Allowance</h3>
-        
+
         <p><span>Call 0800 587 0912<br />
         Email&nbsp;</span><a href="mailto:dcs.incomingpostteamdhc2@nissa.gsi.gov.uk">dcs.incomingpostteamdhc2@nissa.gsi.gov.uk</a></p>
-        
+
         <h3>Discretionary support / Short-term benefit advance</h3>
-        
+
         <p><span>Call 0800 587 2750&nbsp;<br />
         Email&nbsp;</span><a href="mailto:customerservice.unit@communities-ni.gov.uk ">customerservice.unit@communities-ni.gov.uk</a></p>
-        
+
         <h3>Disability Living Allowance</h3>
-        
+
         <p>Call 0800 587 0912&nbsp;<br />
         <span>Email <a href="mailto:dcs.incomingpostteamdhc2@nissa.gsi.gov.uk">dcs.incomingpostteamdhc2@nissa.gsi.gov.uk</a></span></p>
-        
+
         <h3>Employment and Support Allowance</h3>
-        
+
         <p>Call&nbsp;0800 587 1377</p>
-        
+
         <h3>Jobseeker’s Allowance</h3>
-        
+
         <p>Contact your local <a href="/node/2739">Jobs &amp; Benefits office</a></p>
-        
+
         <h3>Personal Independence Payment</h3>
-        
+
         <p>Call 0800 587 0932</p>
-        
+
         <p>If your query is about another benefit, select ‘Other’ from the drop-down menu above.</p>
-        
+
         <p>&nbsp;</p>
-        
+
       '#format': full_html
     blue_badge:
       '#type': processed_text
@@ -313,7 +313,7 @@ elements: |
     '#submit__label': 'Submit feedback'
     '#wizard_prev_hide': true
     '#wizard_next__label': Continue
-  
+
 css: ''
 javascript: ''
 settings:
@@ -404,9 +404,9 @@ settings:
   confirmation_title: 'Thank you for your feedback'
   confirmation_message: |
     <p class="nodeSummary">If you have asked for a reply, we aim to get back to you within 10 working days.</p>
-    
+
     <p>All responses will usually be sent out Monday to Friday, 9.00 am to 5.00 pm (excluding public and bank holidays).</p>
-    
+
   confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
@@ -521,14 +521,78 @@ handlers:
       from_name: 'nidirect visitor'
       subject: 'Feedback form submission'
       body: |
-        Last page viewed: https://www.nidirect.gov.uk[current-page:query:s]<br />
-        Submitted:&nbsp;[webform_submission:completed:long]&nbsp;by user: [webform_submission:user]<br />
+        Last page viewed: https://www.nidirect.gov.uk[current-page:query:s]
+        Submitted on [webform_submission:created]
+        Submitted by: [webform_submission:user]
+
+        Submitted values are:
+        [webform_submission:values]
+
+      excluded_elements:
+        important_information: important_information
+        do_you_wish_to_report_an_issue_or_make_a_comment: do_you_wish_to_report_an_issue_or_make_a_comment
+        angling: angling
+        benefits: benefits
+        blue_badge: blue_badge
+        careers: careers
+        child_maintenance: child_maintenance
+        claiming_compensation_road_problem: claiming_compensation_road_problem
+        criminal_record_checks: criminal_record_checks
+        ema: ema
+        employment_rights: employment_rights
+        groni: groni
+        motoring: motoring
+        passports: passports
+        pcn: pcn
+        pensions: pensions
+        proni: proni
+        rates: rates
+        report_a_fault: report_a_fault
+        smartpass: smartpass
+      ignore_access: false
+      exclude_empty: true
+      exclude_empty_checkbox: false
+      exclude_attachments: false
+      html: false
+      attachments: false
+      twig: false
+      debug: false
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      theme_name: ''
+      parameters: {  }
+  email_1:
+    id: email
+    label: 'Auto reply'
+    notes: ''
+    handler_id: email_1
+    status: true
+    conditions:
+      enabled:
+        ':input[name="do_you_want_us_to_reply_to_you"]':
+          value: 'Yes'
+        ':input[name="email"]':
+          filled: true
+    weight: 0
+    settings:
+      states:
+        - completed
+      to_mail: '[webform_submission:values:email:raw]'
+      to_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      from_mail: noreply@nidirect.gov.uk
+      from_options: {  }
+      from_name: nidirect.gov.uk
+      subject: 'Thank you for your feedback on nidirect.gov.uk'
+      body: |
+        Thank you for your feedback.<br />
         <br />
-        ---------------------------------------------------------------------------------------------<br />
-        [webform_submission:values]<br />
-        <br />
-        ---------------------------------------------------------------------------------------------
-        
+        We aim to get back to you within 10 working days.&nbsp; All responses will usually be sent out Monday to Friday, 9.00 am to 5.00 pm (excluding public and bank holidays). This is an automated email message. Please do not reply to this email as we do not have access to emails sent to noreply@nidirect.gov.uk.
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true

--- a/config/sync/webform.webform.your_comments.yml
+++ b/config/sync/webform.webform.your_comments.yml
@@ -631,16 +631,16 @@ handlers:
       from_name: 'nidirect visitor'
       subject: 'Page feedback'
       body: |
-        Page feedback for: [webform_submission:values:your_feedback:page_url] ==Submitted values==<br />
-        <br />
-        [webform_submission:values]<br />
-        --------------------------------------------------------------------------------------------- Submitted: [webform_submission:completed:long]
+        Submitted on [webform_submission:created]
+        
+        Submitted values are:
+        [webform_submission:values]
         
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true
       exclude_empty_checkbox: false
-      html: true
+      html: false
       attachments: false
       twig: false
       debug: false
@@ -657,7 +657,12 @@ handlers:
     notes: ''
     handler_id: auto_reply
     status: true
-    conditions: {  }
+    conditions:
+      enabled:
+        ':input[name="do_you_want_a_reply_options"]':
+          value: 'Yes'
+        ':input[name="enter_a_valid_email_address"]':
+          filled: true
     weight: 0
     settings:
       states:
@@ -673,19 +678,11 @@ handlers:
       from_name: NIDirect
       subject: 'Thank you for your feedback on nidirect.gov.uk'
       body: |
-        Thank you for your feedback on [webform_submission:values:your_feedback:page_url].
-        
-        Your feedback:
-        --------------------------------------------------------------------
-        [webform_submission:values:your_feedback:comment_details][webform_submission:values:your_feedback:question_details]
-        --------------------------------------------------------------------
-        
-        We aim to get back to you within 10 working days. 
-        All responses will usually be sent out Monday to Friday, 9.00 am to 5.00 pm (excluding public and bank holidays).
-        
-        This is an automated email message. Please do not reply to this email as we do not have access to emails sent to noreply@nidirect.gov.uk.
-        
-      excluded_elements: {  }
+        Thank you for your feedback.<br />
+        <br />
+        We aim to get back to you within 10 working days.&nbsp; All responses will usually be sent out Monday to Friday, 9.00 am to 5.00 pm (excluding public and bank holidays). This is an automated email message. Please do not reply to this email as we do not have access to emails sent to noreply@nidirect.gov.uk.
+      excluded_elements:
+        page_url: page_url
       ignore_access: false
       exclude_empty: true
       exclude_empty_checkbox: false


### PR DESCRIPTION
- Add auto reply email to site feedback form (top nav one) in line with same on page feedback form
- Simple thank you auto reply - does not contain the info the user submitted.
- Auto reply conditional - only enable if user wants a reply and provided and email address
- Plain text format for emails sent to CET
- Exclude HTML form elements from the email sent to CET