### PR TITLE
Remove migrate config sync script from deploy steps

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -83,8 +83,7 @@ hooks:
     drush -y updatedb
     # General config import
     drush -y config-import
-    # Force partial imports of migration config.
-    ../migrate-config-sync.sh
+    # Final cache rebuild.
     drush -y cache-rebuild
 # The configuration of app when it is exposed to the web.
 web:


### PR DESCRIPTION
Suggest we leave removing migrate config and modules until a stable period after launch.