### PR TITLE
D8NID-1356: Remove unwanted migrate modules to permit MAS articles to import

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -84,9 +84,7 @@ module:
   metatag_twitter_cards: 0
   metatag_verification: 0
   migrate: 0
-  migrate_absolute_links: 0
   migrate_plus: 0
-  migrate_process_trim: 0
   migrate_tools: 0
   moderation_sidebar: 0
   multiline_config: 0

--- a/config/sync/migrate_plus.migration.money_advice_service_rss_articles.yml
+++ b/config/sync/migrate_plus.migration.money_advice_service_rss_articles.yml
@@ -1,7 +1,9 @@
-uuid: 6ac66ae9-b073-4365-ba89-82680f5e5351
+uuid: 928e45ac-3ce4-44d4-a116-f23e46bcf57d
 langcode: en
 status: true
 dependencies: {  }
+_core:
+  default_config_hash: qQi97vXvGPzf7nKi-Y3ZG4JmVbb8vsGtxAn6R6uMTf8
 id: money_advice_service_rss_articles
 class: null
 field_plugin_method: null

--- a/config/sync/ultimate_cron.job.money_advice_articles.yml
+++ b/config/sync/ultimate_cron.job.money_advice_articles.yml
@@ -1,4 +1,4 @@
-uuid: 46f892fc-88d6-4381-8896-6beab8697a6d
+uuid: 8997bc7f-222c-4824-87fa-dd04865f4a19
 langcode: en
 status: true
 dependencies:


### PR DESCRIPTION
Includes updated MAS article import config hashes.

NB: Ahead of deployment:

* Uninstall all migrate modules (purges config)
* Deploy code; config import will pull in the config from config/sync and make it active in the database.

Once in place: `drush ms` to test. If you get a migrate plugin error, the existing config hasn't been correctly purged before importing the new.