### PR TITLE
Swap to message confirmation and remove embedded markup

### DIFF
--- a/config/sync/webform.webform.site_feedback.yml
+++ b/config/sync/webform.webform.site_feedback.yml
@@ -408,7 +408,7 @@ settings:
   draft_loaded_message: ''
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
-  confirmation_type: page
+  confirmation_type: message
   confirmation_title: 'Thank you for your feedback'
   confirmation_message: |
     <p class="nodeSummary">If you have asked for a reply, we aim to get back to you within 10 working days.</p>

--- a/config/sync/webform.webform.your_comments.yml
+++ b/config/sync/webform.webform.your_comments.yml
@@ -523,13 +523,9 @@ settings:
   draft_loaded_message: ''
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
-  confirmation_type: inline
+  confirmation_type: message
   confirmation_title: ''
-  confirmation_message: |
-    <div class="info-notice info-notice--success">
-    <p><strong>Thank you for your feedback</strong></p>
-    </div>
-
+  confirmation_message: 'Thank you for your feedback'
   confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: false


### PR DESCRIPTION
Standardises the response format for anon + auth users as AJAX submission/response doesn't seem to work for anon users without the use of a CSRF token, which Drupal core does not add for anonymous users.

Markup removed from config: it was used to display the correct format in the inline response but it doubles up with the existing status area messages markup when using the messages confirmation option.