### PR TITLE
A11y fixes

### DIFF
--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -301,7 +301,7 @@ display:
           exposed: true
           expose:
             operator_id: search_api_fulltext_op
-            label: 'Search this site ...'
+            label: 'Search n i direct'
             description: ''
             use_operator: false
             operator: search_api_fulltext_op
@@ -326,7 +326,9 @@ display:
               health_condition_author_user: '0'
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
-            placeholder: ''
+            placeholder: 'Search nidirect'
+            expose_fields: false
+            searched_fields_id: ''
           is_grouped: false
           group_info:
             label: ''
@@ -838,10 +840,12 @@ display:
           exposed: true
           expose:
             operator_id: search_api_fulltext_op
-            label: ''
+            label: 'Search n i direct'
             description: ''
             use_operator: false
             operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: query
             required: true
             remember: false
@@ -862,8 +866,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: 'Search nidirect'
-            operator_limit_selection: false
-            operator_list: {  }
+            expose_fields: false
+            searched_fields_id: ''
           is_grouped: false
           group_info:
             label: ''

--- a/config/sync/webform.webform.contact_the_make_the_call_team.yml
+++ b/config/sync/webform.webform.contact_the_make_the_call_team.yml
@@ -165,7 +165,7 @@ elements: |
       '#counter_minimum': 2
       '#counter_maximum': 750
   extra_comments_for_pooh_bear:
-      '#type': textarea
+      '#type': textfield
       '#title': 'Extra comments (optional)'
       '#pattern': '^(?![\s\S])'
       '#pattern_error': 'There was a problem with the extra comments you have provided'
@@ -391,7 +391,6 @@ handlers:
         <p>Submitted on [webform_submission:created:long]</p>
         <p>Submitted values are:</p>
         [webform_submission:values]
-
       excluded_elements:
         do_you_live_in_northern_ireland: do_you_live_in_northern_ireland
       ignore_access: false
@@ -440,7 +439,6 @@ handlers:
         Make the Call Team<br />
         &nbsp;<br />
         Please note: This email was been sent from a notification-only email address that can&rsquo;t accept replies. Please do not reply to this message.
-
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true

--- a/config/sync/webform.webform.debt_management_enquiry.yml
+++ b/config/sync/webform.webform.debt_management_enquiry.yml
@@ -124,7 +124,7 @@ elements: |
       '#pattern': '^(?!.*<[^>]+>).*'
       '#pattern_error': 'HTML or markup is not permitted.'
   extra_comments_for_pooh_bear:
-      '#type': textarea
+      '#type': textfield
       '#title': 'Extra comments (optional)'
       '#pattern': '^(?![\s\S])'
       '#pattern_error': 'There was a problem with the extra comments you have provided'
@@ -344,7 +344,6 @@ handlers:
         &lt;p&gt;Submitted on [current-date:long]&lt;/p&gt;<br />
         &lt;p&gt;Submitted values are:&lt;/p&gt;<br />
         [webform_submission:values]
-
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true

--- a/config/sync/webform.webform.landlord_direct_payments.yml
+++ b/config/sync/webform.webform.landlord_direct_payments.yml
@@ -224,7 +224,7 @@ elements: |
 
     '#format': full_html
   extra_comments_for_pooh_bear:
-      '#type': textarea
+      '#type': textfield
       '#title': 'Extra comments (optional)'
       '#pattern': '^(?![\s\S])'
       '#pattern_error': 'There was a problem with the extra comments you have provided'

--- a/config/sync/webform.webform.mother_and_baby_and_magdalene_la.yml
+++ b/config/sync/webform.webform.mother_and_baby_and_magdalene_la.yml
@@ -72,7 +72,7 @@ elements: |
         ':input[name="do_you_live_in_northern_ireland_"]':
           value: 'Yes'
   extra_comments_for_pooh_bear:
-      '#type': textarea
+      '#type': textfield
       '#title': 'Extra comments (optional)'
       '#pattern': '^(?![\s\S])'
       '#pattern_error': 'There was a problem with the extra comments you have provided'
@@ -325,7 +325,6 @@ handlers:
         <p><strong>Thank you for submitting your expression of interest</strong></p>
 
         <p>You do not need to do anything. The Support Team will be in contact within the next 5 working days.</p>
-
       excluded_elements:
         intro_text: intro_text
         name: name

--- a/config/sync/webform.webform.proni_submit_an_enquiry.yml
+++ b/config/sync/webform.webform.proni_submit_an_enquiry.yml
@@ -47,7 +47,7 @@ elements: |
       '#pattern': '[^@\s]+@[^@\s]+\.[^@\s]+'
       '#pattern_error': 'You must enter a valid email address, for example, name@example.com'
   extra_comments_for_pooh_bear:
-    '#type': textarea
+    '#type': textfield
     '#title': 'Extra comments (optional)'
     '#pattern': '^(?![\s\S])'
     '#pattern_error': 'There was a problem with the extra comments you have provided'
@@ -58,7 +58,6 @@ elements: |
     '#type': webform_actions
     '#title': 'Submit button(s)'
     '#submit__label': 'Submit enquiry'
-
 css: ''
 javascript: ''
 settings:

--- a/config/sync/webform.webform.report_legal_aid_fraud.yml
+++ b/config/sync/webform.webform.report_legal_aid_fraud.yml
@@ -689,7 +689,7 @@ elements: |
       '#counter_minimum': 1
       '#counter_maximum': 1000
   extra_comments_for_pooh_bear:
-      '#type': textarea
+      '#type': textfield
       '#title': 'Extra comments (optional)'
       '#pattern': '^(?![\s\S])'
       '#pattern_error': 'There was a problem with the extra comments you have provided'

--- a/config/sync/webform.webform.site_feedback.yml
+++ b/config/sync/webform.webform.site_feedback.yml
@@ -110,7 +110,7 @@ elements: |
           ':input[name="do_you_want_us_to_reply_to_you"]':
             value: 'Yes'
     extra_comments_for_pooh_bear:
-        '#type': textarea
+        '#type': textfield
         '#title': 'Extra comments (optional)'
         '#pattern': '^(?![\s\S])'
         '#pattern_error': 'There was a problem with the extra comments you have provided'
@@ -321,7 +321,6 @@ elements: |
     '#submit__label': 'Submit feedback'
     '#wizard_prev_hide': true
     '#wizard_next__label': Continue
-
 css: ''
 javascript: ''
 settings:
@@ -414,7 +413,6 @@ settings:
     <p class="nodeSummary">If you have asked for a reply, we aim to get back to you within 10 working days.</p>
 
     <p>All responses will usually be sent out Monday to Friday, 9.00 am to 5.00 pm (excluding public and bank holidays).</p>
-
   confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
@@ -535,7 +533,6 @@ handlers:
 
         Submitted values are:
         [webform_submission:values]
-
       excluded_elements:
         important_information: important_information
         do_you_wish_to_report_an_issue_or_make_a_comment: do_you_wish_to_report_an_issue_or_make_a_comment

--- a/config/sync/webform.webform.state_pension_online_feedback.yml
+++ b/config/sync/webform.webform.state_pension_online_feedback.yml
@@ -42,14 +42,13 @@ elements: |
       '#counter_type': character
       '#counter_maximum': 750
   extra_comments_for_pooh_bear:
-      '#type': textarea
+      '#type': textfield
       '#title': 'Extra comments (optional)'
       '#pattern': '^(?![\s\S])'
       '#pattern_error': 'There was a problem with the extra comments you have provided'
       '#wrapper_attributes':
         class:
           - for-pooh-bear
-
 css: ''
 javascript: ''
 settings:
@@ -144,7 +143,6 @@ settings:
     <p>If you have requested a reply, we aim to get back to you within 10 working days. All responses will be issued Monday to Friday, 9.00am to 5.00pm (excluding public and bank holidays).</p>
 
     <p>If you did not request a reply, we will give your comments careful consideration.</p>
-
   confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: false
@@ -261,7 +259,6 @@ handlers:
       body: |
         &lt;p&gt;Submitted on [current-date:long]&lt;/p&gt;<br />
         [webform_submission:values]
-
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true

--- a/config/sync/webform.webform.your_comments.yml
+++ b/config/sync/webform.webform.your_comments.yml
@@ -170,7 +170,7 @@ elements: |
           ':input[name="is_your_feedback_about"]':
             value: question_other
   extra_comments_for_pooh_bear:
-      '#type': textarea
+      '#type': textfield
       '#title': 'Extra comments (optional)'
       '#pattern': '^(?![\s\S])'
       '#pattern_error': 'There was a problem with the extra comments you have provided'


### PR DESCRIPTION
- Set search label and placeholder so that they are consistent - note spacing in label is deliberate to ensure correct pronunciation by screen readers
- Change extra_comments_for_pooh_bear into a textfield instead of textarea because regex pattern attributes added to textareas are not valid HTML