### PR TITLE
Remove regex pattern validation on textareas in various webforms

### DIFF
--- a/config/sync/webform.webform.contact_the_make_the_call_team.yml
+++ b/config/sync/webform.webform.contact_the_make_the_call_team.yml
@@ -159,8 +159,6 @@ elements: |
       '#description_display': before
       '#required': true
       '#required_error': 'You must explain why you cannot make contact by phone'
-      '#pattern': '^(?!.*<[^>]+>).*'
-      '#pattern_error': 'HTML or markup is not permitted.'
       '#counter_type': character
       '#counter_minimum': 2
       '#counter_maximum': 750

--- a/config/sync/webform.webform.debt_management_enquiry.yml
+++ b/config/sync/webform.webform.debt_management_enquiry.yml
@@ -121,8 +121,6 @@ elements: |
       '#description_display': before
       '#maxlength': 3000
       '#required': true
-      '#pattern': '^(?!.*<[^>]+>).*'
-      '#pattern_error': 'HTML or markup is not permitted.'
   extra_comments_for_pooh_bear:
       '#type': textfield
       '#title': 'Extra comments (optional)'

--- a/config/sync/webform.webform.proni_submit_an_enquiry.yml
+++ b/config/sync/webform.webform.proni_submit_an_enquiry.yml
@@ -22,8 +22,6 @@ elements: |
       '#placeholder': 'Plain text only (3,000 characters maximum)'
       '#required': true
       '#required_error': 'You must fill in this field'
-      '#pattern': '^(?!.*<[^>]+>).*'
-      '#pattern_error': 'HTML or markup is not permitted.'
       '#counter_type': character
       '#counter_maximum': 3000
   your_details:

--- a/config/sync/webform.webform.state_pension_online_feedback.yml
+++ b/config/sync/webform.webform.state_pension_online_feedback.yml
@@ -37,8 +37,6 @@ elements: |
       '#placeholder': 'Plain text only, 750 characters maximum.'
       '#required': true
       '#required_error': 'Please fill in this field'
-      '#pattern': '^(?!.*<[^>]+>).*'
-      '#pattern_error': 'HTML or markup is not permitted.'
       '#counter_type': character
       '#counter_maximum': 750
   extra_comments_for_pooh_bear:


### PR DESCRIPTION
The pattern attribute on textareas is usually used to prevent submission of html - and browsers seem to support it ok - but it is not allowed in the html spec ...