### PR TITLE
Turn off antibot right before functional tests execute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,10 @@ jobs:
               npm install
             done
       - run:
+          name: Switch off antibot module
+          command: |
+            platform environment:drush pmu antibot -y -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
+      - run:
           name: Run tests with Nightwatch.js
           command: |
             yarn --cwd=/home/circleci/project/web/core test:nightwatch $(for tag in $TEST_TAGS; do echo --tag $tag; done)


### PR DESCRIPTION
otherwise nightwatch is classified as a spam bot