### PR TITLE
Page max age adjustment

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -119,7 +119,7 @@ web:
       # and a stale item can be served whilst Fastly fetches a fresh one from
       # the backend. Only Fastly sees the Surrogate-Control header and
       # removes it from its response. Since purging items from Fastly cache
-      # happens when content is updated it is safe to set long TTL.
+      # happens when content is updated it is safe to set a long TTL.
       headers:
         Surrogate-Control: max-age=86400, stale-while-revalidate=60
 

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -115,6 +115,14 @@ web:
       # Deny access to static files in this location.
       allow: false
 
+      # Set Surrogate-Control for Fastly so that things are cached for 24 hours
+      # and a stale item can be served whilst Fastly fetches a fresh one from
+      # the backend. Only Fastly sees the Surrogate-Control header and
+      # removes it from its response. Since purging items from Fastly cache
+      # happens when content is updated it is safe to set long TTL.
+      headers:
+        Surrogate-Control: max-age=86400, stale-while-revalidate=60
+
       # Rules for specific URI patterns.
       rules:
         # Allow access to common static files.

--- a/config/development/system.performance.yml
+++ b/config/development/system.performance.yml
@@ -1,6 +1,6 @@
 cache:
   page:
-    max_age: 31536000
+    max_age: 300
 css:
   preprocess: true
   gzip: true

--- a/config/production/system.performance.yml
+++ b/config/production/system.performance.yml
@@ -1,6 +1,6 @@
 cache:
   page:
-    max_age: 31536000
+    max_age: 300
 css:
   preprocess: true
   gzip: true

--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -1,6 +1,6 @@
 cache:
   page:
-    max_age: 31536000
+    max_age: 300
 css:
   preprocess: true
   gzip: true


### PR DESCRIPTION
Adjust cache-control max-age to 5 mins instead of 1 year.  We don't want browsers or proxies to cache pages for that long.  Set Surrogate-Control header for Fastly and let Fastly cache a page for 24 hours.