### PR TITLE
Enable http cache control module and set cache-control and surrogate-control values

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -65,6 +65,7 @@ module:
   handy_cache_tags: 0
   help: 0
   hms_field: 0
+  http_cache_control: 0
   image: 0
   inline_entity_form: 0
   inline_form_errors: 0
@@ -172,7 +173,6 @@ module:
   twig_field_value: 0
   twig_tweak: 0
   ultimate_cron: 0
-  update: 0
   user: 0
   views_contextual_filters_or: 0
   views_custom_cache_tag: 0

--- a/config/sync/http_cache_control.settings.yml
+++ b/config/sync/http_cache_control.settings.yml
@@ -1,0 +1,15 @@
+cache:
+  http:
+    s_maxage: 0
+    404_max_age: 0
+    302_max_age: 0
+    301_max_age: 0
+    5xx_max_age: 0
+    stale_while_revalidate: 180
+    stale_if_error: 180
+    vary: ''
+  surrogate:
+    maxage: 86400
+    nostore: null
+_core:
+  default_config_hash: 7J75jee6uT-qT16hDiNTHOtRFPgAz_ppCBdl7GTo-As

--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -1,6 +1,6 @@
 cache:
   page:
-    max_age: 31536000
+    max_age: 300
 css:
   preprocess: true
   gzip: true


### PR DESCRIPTION
At present, all pages have a cache-control: max-age=315600 (1 year).  This means that browsers and proxies and Fastly can cache for 1 year.

In relation to Fastly, caching for 1 year is not a problem because cached pages are purged when necessary.

But for browsers and proxies, 1 year is too long and there is no mechanism to purge browser and proxy caches.

The http cache control module was already present - just not installed.  The module allows us to set separate headers for controlling browser, proxy and reverse proxies like Fastly.  In relation to Fastly, we can set the surrogate-control header which Fastly will use instead of cache-control if it is present.

- For browsers and proxies we want cache-control: max-age=300, public, stale-if-error=180, stale-while-revalidate=180
- For Fastly, set surrogate control max-age to 24 hours

<img width="805" alt="Screenshot 2021-09-24 at 14 45 15" src="https://user-images.githubusercontent.com/52457988/134684863-6ec5e2ed-d5ce-456c-9b98-31789cb7dac4.png">
<img width="819" alt="Screenshot 2021-09-24 at 14 45 31" src="https://user-images.githubusercontent.com/52457988/134684884-9d076d44-f0ac-4b77-9b77-cf1181cb005c.png">

