### PR TITLE
Updates nidirect_site_modules to 1.0.7 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "dof-dss/nicsdru_origins_theme": "^0.3",
         "dof-dss/nidirect-d8-test-install-profile": "^1.0",
         "dof-dss/nidirect-migrations": "^1.0",
-        "dof-dss/nidirect-site-modules": "^1.0.6",
+        "dof-dss/nidirect-site-modules": "^1.0.7",
         "drupal/address": "^1.7",
         "drupal/admin_toolbar": "^3.0",
         "drupal/adminimal_theme": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6cef469eb372c4bf209f98984ea7b07",
+    "content-hash": "b2b1448dab93c89200fe16c774da6642",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2289,16 +2289,16 @@
         },
         {
             "name": "dof-dss/nidirect-site-modules",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dof-dss/nidirect-site-modules.git",
-                "reference": "d4eb4eb25c4ba4cef51b84bcdbfffb01125ed797"
+                "reference": "9900f404f5f856c7fbf89002513384ee471cda2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nidirect-site-modules/zipball/d4eb4eb25c4ba4cef51b84bcdbfffb01125ed797",
-                "reference": "d4eb4eb25c4ba4cef51b84bcdbfffb01125ed797",
+                "url": "https://api.github.com/repos/dof-dss/nidirect-site-modules/zipball/9900f404f5f856c7fbf89002513384ee471cda2c",
+                "reference": "9900f404f5f856c7fbf89002513384ee471cda2c",
                 "shasum": ""
             },
             "require": {
@@ -2312,9 +2312,9 @@
             ],
             "description": "Drupal modules to provide custom code for NI Direct",
             "support": {
-                "source": "https://github.com/dof-dss/nidirect-site-modules/tree/1.0.6"
+                "source": "https://github.com/dof-dss/nidirect-site-modules/tree/1.0.7"
             },
-            "time": "2021-10-01T12:03:00+00:00"
+            "time": "2021-10-02T11:48:50+00:00"
         },
         {
             "name": "drupal/address",
@@ -20009,5 +20009,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Update to nidirect_site_modules 1.0.7 - contains hotfix for major bug preventing reverting to previous revisions