### PR TITLE
Patch to remove invalid iframe attributes from oembed field formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,8 @@
                 "Layout builder fails to assign inline block access dependencies for the overrides section storage on entities with pending revisions": "https://www.drupal.org/files/issues/2021-03-22/3047022-71.patch",
                 "Support for AjaxResponse implementing CacheableResponseInterface": "https://gist.githubusercontent.com/omahm/cd990b5cdba637fe270ada0702717d9d/raw/60a05babb9747061df201ca9f74afb4b59166f14/cacheableAjaxResponse.patch",
                 "Increase service priority for logger factory": "https://gist.githubusercontent.com/johangant/3023926f40867e14385bd3d87831adfc/raw/174cec09449636263b8dcd01679945677a0d607d/increase_logger_factory_service_priority.patch",
-                "'Negate' form value for condition plugins should be cast to boolean in validation": "https://www.drupal.org/files/issues/2020-03-23/3114467-8.patch"
+                "'Negate' form value for condition plugins should be cast to boolean in validation": "https://www.drupal.org/files/issues/2020-03-23/3114467-8.patch",
+                "Remove invalid iframe attributes from oembed field formatter": "https://www.drupal.org/files/issues/2019-07-31/remove-iframe-attributes-3071446-4.patch"
             },
             "drupal/devel": {
                 "Brings back the Available Methods & Properties tabs for Kint dumps — Issue #221": "https://raw.githubusercontent.com/politsin/snipets/master/patch/kint.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51cedfb2f2af11596f27e2dcb660e979",
+    "content-hash": "2583544c25d213bf9497005845ec72b7",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -6633,7 +6633,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1626702090",
+                    "datestamp": "1637145565",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -17404,8 +17404,8 @@
                     "dev-5.x": "5.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-5.0+19-dev",
-                    "datestamp": "1637161832",
+                    "version": "8.x-5.0+20-dev",
+                    "datestamp": "1637259316",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -21129,5 +21129,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Was originally using a twig template to manipulate iframe attributes and stop deprecated frameborder attributes being output - but it stopped working after D9 upgrade and caused video thumbnails to disappear in the media browser. 

Instead of using twig, found this patch that fixes the oembed field formatter and removes the deprecated iframe attributes.  https://www.drupal.org/project/drupal/issues/3071446

