### PR TITLE
Enable title display on translation help block

### DIFF
--- a/config/sync/block.block.translationhelplink.yml
+++ b/config/sync/block.block.translationhelplink.yml
@@ -15,9 +15,9 @@ provider: null
 plugin: translation_help_block
 settings:
   id: translation_help_block
-  label: 'Translation help link'
+  label: 'Translation help'
   provider: nidirect_common
-  label_display: '0'
+  label_display: visible
 visibility:
   request_path:
     id: request_path


### PR DESCRIPTION
Fixes a11y / valid HTML issue where the translation help section has a missing heading.