### PR TITLE
Fixes for services catalogue json feed:

### DIFF
--- a/config/sync/views.view.services_feed_services_catalogue.yml
+++ b/config/sync/views.view.services_feed_services_catalogue.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.storage.node.field_teaser
     - flag.flag.application_unavailable
     - node.type.application
-    - taxonomy.vocabulary.site_themes
   module:
     - flag
     - link
@@ -19,7 +18,6 @@ dependencies:
     - options
     - rest
     - serialization
-    - taxonomy
     - text
     - user
 id: services_feed_services_catalogue
@@ -751,18 +749,6 @@ display:
       footer: {  }
       empty: {  }
       relationships:
-        term_node_tid:
-          id: term_node_tid
-          table: node_field_data
-          field: term_node_tid
-          relationship: none
-          group_type: group
-          admin_label: term
-          required: false
-          vids:
-            - site_themes
-          entity_type: node
-          plugin_id: node_term_data
         flag_relationship:
           id: flag_relationship
           table: node_field_data
@@ -777,6 +763,7 @@ display:
           plugin_id: flag_relationship
       arguments: {  }
       display_extenders: {  }
+      group_by: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -799,7 +786,10 @@ display:
     display_title: 'REST API Services catalogue'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
       path: services/services-catalogue.json
       pager:
         type: none
@@ -838,7 +828,7 @@ display:
               raw_output: false
             field_assurance_level:
               alias: loa
-              raw_output: false
+              raw_output: true
             field_link:
               alias: app_url
               raw_output: false


### PR DESCRIPTION
- Output loa as raw value (integer)
- Remove theme taxonomy relationship as isn't need and causing duplicates