### PR TITLE
Update nidirect-site-modules to 2.1.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2002,16 +2002,16 @@
         },
         {
             "name": "dof-dss/nidirect-site-modules",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dof-dss/nidirect-site-modules.git",
-                "reference": "645636b8feaaaf1f38b9177997154b16bf7b10a2"
+                "reference": "3ca1cd5b3eebc5414241748ea5f0f33c0e9ee7b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nidirect-site-modules/zipball/645636b8feaaaf1f38b9177997154b16bf7b10a2",
-                "reference": "645636b8feaaaf1f38b9177997154b16bf7b10a2",
+                "url": "https://api.github.com/repos/dof-dss/nidirect-site-modules/zipball/3ca1cd5b3eebc5414241748ea5f0f33c0e9ee7b8",
+                "reference": "3ca1cd5b3eebc5414241748ea5f0f33c0e9ee7b8",
                 "shasum": ""
             },
             "require": {
@@ -2025,9 +2025,9 @@
             ],
             "description": "Drupal modules to provide custom code for NI Direct",
             "support": {
-                "source": "https://github.com/dof-dss/nidirect-site-modules/tree/2.1.1"
+                "source": "https://github.com/dof-dss/nidirect-site-modules/tree/2.1.2"
             },
-            "time": "2022-04-01T15:11:54+00:00"
+            "time": "2022-04-02T08:22:34+00:00"
         },
         {
             "name": "drupal/address",


### PR DESCRIPTION
nidirect-site-modules to 2.1.2 contains hotfix for breadcrumbs on embargoed publications