### PR TITLE
Add missing section heading for top features on homepage

### DIFF
--- a/config/sync/block.block.featuredcontent_covid19.yml
+++ b/config/sync/block.block.featuredcontent_covid19.yml
@@ -15,13 +15,13 @@ provider: null
 plugin: featured_content
 settings:
   id: featured_content
-  label: 'Featured content: COVID-19'
+  label: Featured
+  label_display: visible
   provider: nidirect_homepage
-  label_display: '0'
   featured_items: '16087'
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'


### PR DESCRIPTION
Fixes very minor a11y issue / html validation warning