### PR TITLE
Update eu_cookie_compliance module to latest release candidate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "drupal/entity_embed": "^1.2",
         "drupal/entity_reference_unpublished": "^1.2",
         "drupal/entityqueue": "^1.0",
-        "drupal/eu_cookie_compliance": "^1.8",
+        "drupal/eu_cookie_compliance": "^1.20@RC",
         "drupal/facets": "^1.8",
         "drupal/facets_pretty_paths": "^1.1",
         "drupal/fastly": "^3.9",

--- a/composer.json
+++ b/composer.json
@@ -223,9 +223,6 @@
             "drupal/entity_reference_unpublished": {
                 "Plugin to cover taxonomy term entities": "https://www.drupal.org/files/issues/2021-03-25/3205634-reference-unpublished-taxonomy-terms.patch"
             },
-            "drupal/eu_cookie_compliance": {
-                "Withdraw banner links/buttons are keyboard focusable when banner is hidden from view": "https://gist.githubusercontent.com/neilblair/9feddd2f0121d070cbbc084859b45f8e/raw/173a5ccb35c1b9eac27e863cb95c8f32602bccf3/eu_cookie_compliance_3298345-3.patch"
-            },
             "drupal/google_tag": {
                 "Resolve Html checker errors": "https://www.drupal.org/files/issues/2022-03-29/3272258-2.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45eb56d0188cae53f65ccf644e446fdc",
+    "content-hash": "cd96477f2a51203a4a554a905c0574b6",
     "packages": [
         {
             "name": "alchemy/zippy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39850f10c7e084f8caeace202a897501",
+    "content-hash": "45eb56d0188cae53f65ccf644e446fdc",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5355,29 +5355,29 @@
         },
         {
             "name": "drupal/eu_cookie_compliance",
-            "version": "1.19.0",
+            "version": "1.20.0-rc1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/eu-cookie-compliance.git",
-                "reference": "8.x-1.19"
+                "reference": "8.x-1.20-rc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/eu_cookie_compliance-8.x-1.19.zip",
-                "reference": "8.x-1.19",
-                "shasum": "5a13cd53f87a58501cebd6e560c280ad7274035c"
+                "url": "https://ftp.drupal.org/files/projects/eu_cookie_compliance-8.x-1.20-rc1.zip",
+                "reference": "8.x-1.20-rc1",
+                "shasum": "c9a038c2e926f7c957e24fa4cf0951140bb73902"
             },
             "require": {
-                "drupal/core": "^8.9 || ^9"
+                "drupal/core": "^8.9 || ^9 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.19",
-                    "datestamp": "1633775773",
+                    "version": "8.x-1.20-rc1",
+                    "datestamp": "1661148450",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -21383,6 +21383,7 @@
         "drupal/clientside_validation": 5,
         "drupal/config_readonly": 10,
         "drupal/csv_serialization": 10,
+        "drupal/eu_cookie_compliance": 5,
         "drupal/file_delete_ui": 15,
         "drupal/flag": 20,
         "drupal/layout_builder_modal": 15,


### PR DESCRIPTION
Latest release fixes an issue where the cookie banner pops up again immediately after consent has been withdrawn and cookies are not deleted until the user selects reject cookies.  Now when consent is withdrawn, it behaves as if cookies have been rejected - the banner disappears and relevant cookies are deleted.  User is not bothered with another pop-up.