### PR TITLE
D8NID-1545 solr elevations for probation related nodes

### DIFF
--- a/config/sync/nidirect_search.solr_elevated_id.probation.yml
+++ b/config/sync/nidirect_search.solr_elevated_id.probation.yml
@@ -1,0 +1,8 @@
+uuid: b3040294-804d-4936-be87-52d5c399410a
+langcode: en
+status: true
+dependencies: {  }
+id: probation
+label: probation
+index: default_content
+nodes: '92,4821,83,3716'

--- a/config/sync/nidirect_search.solr_elevated_id.probation_contacts.yml
+++ b/config/sync/nidirect_search.solr_elevated_id.probation_contacts.yml
@@ -1,0 +1,8 @@
+uuid: a74357f2-deaf-4ad5-a6af-135ac2ebd6fe
+langcode: en
+status: true
+dependencies: {  }
+id: probation_contacts
+label: probation
+index: contacts
+nodes: '83,92'


### PR DESCRIPTION
Elevate content relating to probation so that it appears higher in search results versus content relating to probate.