### PR TITLE
Omit test account creation and drop functional test PoC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,15 +237,6 @@ jobs:
               -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
           when: always
       - run:
-          name: Enable test user accounts
-          command: |
-            for username in nw_test_admin nw_test_apps nw_test_authenticated nw_test_author nw_test_editor nw_test_gp_author nw_test_gp_super nw_test_news_super nw_test_super
-            do
-              platform environment:drush user:unblock $username -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
-              platform environment:drush user:password $username $TEST_PASS -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH
-            done
-          when: always
-      - run:
           name: Force purge of Solr index
           command: |
             platform ssh -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH \
@@ -332,16 +323,16 @@ workflows:
       - sync_data
 
   # A workflow to execute our functional tests against our edge branch environment.
-  functional-tests:
-    triggers:
-      - schedule:
-          cron: "0 2 * * 1-5"
-          filters:
-            branches:
-              only:
-                - D8NID-edge
-    jobs:
-      - build
+#  functional-tests:
+#    triggers:
+#      - schedule:
+#          cron: "0 2 * * 1-5"
+#          filters:
+#            branches:
+#              only:
+#                - D8NID-edge
+#    jobs:
+#      - build
 #      - functional_tests:
 #          requires:
 #            - build


### PR DESCRIPTION
We have an origins module for creating test accounts now and the QA team have their own automated regression test suite to replace nightwatch from the development phase of the project.