### PR TITLE
Move fastly config into production config split to allow it to disable on hosted environments

### DIFF
--- a/config/production/fastly.settings.yml
+++ b/config/production/fastly.settings.yml
@@ -1,1 +1,1 @@
-site_id: 'master'
+site_id: master

--- a/config/sync/config_split.config_split.production.yml
+++ b/config/sync/config_split.config_split.production.yml
@@ -13,5 +13,7 @@ module:
   fastly: 0
   permissions_filter: 0
 theme: {  }
+blacklist:
+  - fastly.settings
 complete_list: {  }
 partial_list: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -52,7 +52,6 @@ module:
   facets: 0
   facets_pretty_paths: 0
   facets_summary: 0
-  fastly: 0
   field: 0
   field_group: 0
   field_ui: 0

--- a/config/sync/fastly.settings.yml
+++ b/config/sync/fastly.settings.yml
@@ -1,1 +1,0 @@
-site_id: master


### PR DESCRIPTION
Fastly should only activate when building/deploying on the detected production environment. It does that by setting the production profile to active in settings.php (detecting a PSH branch env var) and merges the config it finds in that folder with the standard profile. This is how it's done on the Unity and Dept projects so perhaps we had it a bit backwards when we first set this up for NIDirect.