### PR TITLE
D8NID-1574 search autocomplete tweaks

### DIFF
--- a/config/sync/search_api_autocomplete.search.contacts.yml
+++ b/config/sync/search_api_autocomplete.search.contacts.yml
@@ -17,6 +17,10 @@ suggester_settings:
       - body
       - field_supplementary_contact
       - title_fulltext
+    highlight:
+      enabled: false
+      field: ''
+    suggest_keys: false
     view_modes:
       'entity:node':
         contact: ''
@@ -33,8 +37,8 @@ search_settings:
         - contact_search
 options:
   limit: 5
-  min_length: 2
+  min_length: 3
   show_count: false
-  delay: null
+  delay: 500
   submit_button_selector: ':submit'
   autosubmit: true

--- a/config/sync/search_api_autocomplete.search.health_conditions.yml
+++ b/config/sync/search_api_autocomplete.search.health_conditions.yml
@@ -14,9 +14,14 @@ index_id: health_conditions
 suggester_settings:
   live_results:
     fields: {  }
+    highlight:
+      enabled: false
+      field: ''
+    suggest_keys: false
     view_modes:
       'entity:node':
         health_condition: ''
+        health_condition_alternative: ''
 suggester_weights:
   live_results: 0
 suggester_limits:
@@ -29,8 +34,8 @@ search_settings:
         - default
 options:
   limit: 5
-  min_length: 2
+  min_length: 3
   show_count: false
-  delay: null
+  delay: 500
   submit_button_selector: ':submit'
   autosubmit: true

--- a/config/sync/search_api_autocomplete.search.search.yml
+++ b/config/sync/search_api_autocomplete.search.search.yml
@@ -14,20 +14,24 @@ index_id: default_content
 suggester_settings:
   live_results:
     fields: {  }
+    highlight:
+      enabled: false
+      field: ''
+    suggest_keys: false
     view_modes:
+      'entity:gp':
+        gp: ''
       'entity:node':
         application: ''
         article: ''
         contact: ''
-        driving_instructor: ''
         embargoed_publication: ''
         gp_practice: ''
+        health_condition: ''
         landing_page: ''
         news: ''
         page: ''
         publication: ''
-        recipe: ''
-        umbrella_body: ''
 suggester_weights:
   live_results: 0
 suggester_limits:
@@ -40,8 +44,8 @@ search_settings:
         - default
 options:
   limit: 5
-  min_length: 2
+  min_length: 3
   show_count: false
-  delay: null
+  delay: 500
   submit_button_selector: ':submit'
   autosubmit: true


### PR DESCRIPTION
Increase minimum keyword length to 3 and delay search suggestions by 500ms (instead of default of 300ms)