### PR TITLE
Add sizing hints to .platform.app.yaml for better performance

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -26,6 +26,10 @@ runtime:
     - apcu
     - newrelic
     - redis
+  # Sizing hints.
+  sizing_hints:
+    request_memory: 56
+    reserved_memory: 70
 
 # The relationships of the application with services or other applications.
 #


### PR DESCRIPTION
There have been a few instances of production exceeding memory quotas and new relic alerts in relation to low apdex.

<img width="536" alt="Screenshot 2023-03-03 at 17 57 22" src="https://user-images.githubusercontent.com/52457988/222793516-41987ef6-d4d0-4355-80b1-c2bc9e3738d3.png">

It may be prudent to optimise PHP-FPM workers - see https://docs.platform.sh/languages/php/fpm.html

Platform sets the request memory for PHP-FPM workers to 45MB by default.  However, it seems that the majority (around 75%) of PHP requests on nidirect production use somewhere between 45MB and 56MB. The default request memory is therefore too low, possibly allows too many concurrent requests, and may be resulting in memory swapping and latencies.

Increase request memory for php-fpm workers from the default of 45 to 56.

