### PR TITLE
Use 9.x-dev in favour of legacy development branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ commands:
           name: Switch dof-dss packages to HEAD on develelopment branch
           command: |
             composer require dof-dss/nidirect-d8-test-install-profile:dev-development \
-                             dof-dss/nicsdru_origins_theme:dev-development \
-                             dof-dss/nicsdru_origins_modules:dev-development
+                             dof-dss/nicsdru_origins_theme:dev-9.x-dev \
+                             dof-dss/nicsdru_origins_modules:dev-9.x-dev
   hosts_keyscan:
     description: "Keyscan for hosts that require SSH access"
     steps:


### PR DESCRIPTION
NB nidirect-d8-test-install-profile hasn't been affected