### PR TITLE
D8 nid 1623

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
         "drupal/paragraphs": "^1.8",
         "drupal/pathauto": "^1.12",
         "drupal/permissions_filter": "^1.2",
-        "drupal/redirect": "^1.5",
+        "drupal/redirect": "^1.9",
         "drupal/redis": "^1.5",
         "drupal/scheduled_transitions": "^2.1",
         "drupal/scheduler": "^1.4",
@@ -228,7 +228,6 @@
                 "Cache Expiration doesn't follow Drupal conventions #2877893": "https://www.drupal.org/files/issues/fix-ttl-logic-2877893-1.patch"
             },
             "drupal/redirect": {
-                "URL redirects listing only displays operations": "https://www.drupal.org/files/issues/2019-04-05/redirects_list_builder-3031125-9-d8.patch",
                 "Add URL Redirects tab to taxonomy term edit form": "https://www.drupal.org/files/issues/2021-03-26/redirect_provide_redirect_tab_on_taxonomy_terms_3205896.patch",
                 "Fix ajax error when creating redirects": "https://www.drupal.org/files/issues/2020-12-14/validation-issue-3057250-29.patch",
                 "Empty query params on source cause TypeError": "https://www.drupal.org/files/issues/2022-10-25/3315928-7-redirect-empty-source-query-options.patch"

--- a/composer.json
+++ b/composer.json
@@ -235,6 +235,9 @@
             },
             "drupal/scheduled_transitions": {
                 "No scheduled revisions appear for migrated nodes": "https://www.drupal.org/files/issues/2021-11-01/scheduled_transitions_base_language_3091006_2x.patch"
+            },
+            "drupal/ultimate_cron": {
+                "Apply entityQuery accessCheck CR #3334805": "https://www.drupal.org/files/issues/2023-10-31/ultime-cron-entity-query-3334805-5.patch"
             }
         },
         "composer-exit-on-patch-failure": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddc276d7ce917a0e65027c42e6ed601e",
+    "content-hash": "4a4a1471ffa9e817cbaba998556f2ea4",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8812235d43d51211403cf6b33dadee49",
+    "content-hash": "ddc276d7ce917a0e65027c42e6ed601e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8003,17 +8003,17 @@
         },
         {
             "name": "drupal/simple_sitemap",
-            "version": "4.1.6",
+            "version": "4.1.7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/simple_sitemap.git",
-                "reference": "4.1.6"
+                "reference": "4.1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-4.1.6.zip",
-                "reference": "4.1.6",
-                "shasum": "5ea5ee97ab4d59b43db86dd6279c3ac5ecbe69b9"
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-4.1.7.zip",
+                "reference": "4.1.7",
+                "shasum": "3d55ee386b0ebb81ed4c3461451a9e32a15d93d7"
             },
             "require": {
                 "drupal/core": "^9.3 || ^10",
@@ -8022,8 +8022,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.1.6",
-                    "datestamp": "1686288643",
+                    "version": "4.1.7",
+                    "datestamp": "1698936269",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/web/modules/custom/nidirect_common/nidirect_common.install
+++ b/web/modules/custom/nidirect_common/nidirect_common.install
@@ -11,6 +11,8 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
+use Drupal\views\Entity\View;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Implements hook_install().
@@ -299,6 +301,26 @@ function nidirect_common_update_8004() {
     );
   }
 }
+
+/**
+ * Creates the new default redirect view to fix D8NID-1623.
+ */
+function nidirect_common_update_8005() {
+  $message = NULL;
+
+  // Only create if the redirect view doesn't exist and views is enabled.
+  if (!View::load('redirect') && \Drupal::moduleHandler()->moduleExists('views')) {
+    $config_path = \Drupal::service('extension.list.module')->getPath('redirect') . '/config/install/views.view.redirect.yml';
+    $data = Yaml::parse(file_get_contents($config_path));
+    \Drupal::configFactory()->getEditable('views.view.redirect')->setData($data)->save(TRUE);
+    $message = 'The new redirect view has been created.';
+  }
+  else {
+    $message = 'Not creating a redirect view since it already exists.';
+  }
+  return $message;
+}
+
 
 /**
  * Return a list of nids with problematic telephone numbers.


### PR DESCRIPTION
Shifting from Listbuilder to the bundled (and maintained) View with Redirect. ListBuilder patch was missing the accessCheck() call required in 9.2+ and I don't want to rely on this patch being updated for any future core changes. 