### PR TITLE
Re-rolled patch for displaying revisions in modal list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -232,7 +232,7 @@
                 "Empty query params on source cause TypeError": "https://www.drupal.org/files/issues/2022-10-25/3315928-7-redirect-empty-source-query-options.patch"
             },
             "drupal/scheduled_transitions": {
-                "No scheduled revisions appear for migrated nodes": "https://www.drupal.org/files/issues/2021-11-01/scheduled_transitions_base_language_3091006_2x.patch"
+                "Add pagination to target revision candidates list": "https://www.drupal.org/files/issues/2023-11-20/3241497-12.patch"
             },
             "drupal/ultimate_cron": {
                 "Apply entityQuery accessCheck CR #3334805": "https://www.drupal.org/files/issues/2023-10-31/ultime-cron-entity-query-3334805-5.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f2039bf35f5e979a723eed0874e9b53",
+    "content-hash": "6c527c9c115226fe94aee51aa99c75fb",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Appears to provide a big performance improvement for scheduling transitions on nodes with very large numbers of revisions. Includes prior patch referenced in the composer.json file 