### PR TITLE
Prison visits virtual from json

### DIFF
--- a/config/sync/webform.webform.prison_visit_online_booking.yml
+++ b/config/sync/webform.webform.prison_visit_online_booking.yml
@@ -1557,6 +1557,7 @@ handlers:
       subject: OV_IN
       body: |-
         {
+        "SEQUENCE_ID": "[webform_submission:serial]",
         "SUBMITTED_DATETIME": "[webform_submission:completed:prison_visit_booking_datetime]",
         "VISIT_ORDER_NO": "[webform_submission:values:visitor_order_number]",
         "INMATE_ID": "[webform_submission:values:prisoner_id]",
@@ -1652,6 +1653,7 @@ handlers:
       subject: OV_IN
       body: |-
         {
+        "SEQUENCE_ID": "[webform_submission:serial]",
         "SUBMITTED_DATETIME": "[webform_submission:completed:prison_visit_booking_datetime]",
         "VISIT_ORDER_NO": "[webform_submission:values:visitor_order_number]",
         "INMATE_ID": "[webform_submission:values:prisoner_id]",
@@ -1747,6 +1749,7 @@ handlers:
       subject: OV_IN
       body: |-
         {
+        "SEQUENCE_ID": "[webform_submission:serial]",
         "SUBMITTED_DATETIME": "[webform_submission:completed:prison_visit_booking_datetime]",
         "VISIT_ORDER_NO": "[webform_submission:values:visitor_order_number]",
         "INMATE_ID": "[webform_submission:values:prisoner_id]",

--- a/web/modules/custom/nidirect_webforms/config/install/webform.webform.prison_visit_online_booking.yml
+++ b/web/modules/custom/nidirect_webforms/config/install/webform.webform.prison_visit_online_booking.yml
@@ -1557,6 +1557,7 @@ handlers:
       subject: OV_IN
       body: |-
         {
+        "SEQUENCE_ID": "[webform_submission:serial]",
         "SUBMITTED_DATETIME": "[webform_submission:completed:prison_visit_booking_datetime]",
         "VISIT_ORDER_NO": "[webform_submission:values:visitor_order_number]",
         "INMATE_ID": "[webform_submission:values:prisoner_id]",
@@ -1652,6 +1653,7 @@ handlers:
       subject: OV_IN
       body: |-
         {
+        "SEQUENCE_ID": "[webform_submission:serial]",
         "SUBMITTED_DATETIME": "[webform_submission:completed:prison_visit_booking_datetime]",
         "VISIT_ORDER_NO": "[webform_submission:values:visitor_order_number]",
         "INMATE_ID": "[webform_submission:values:prisoner_id]",
@@ -1747,6 +1749,7 @@ handlers:
       subject: OV_IN
       body: |-
         {
+        "SEQUENCE_ID": "[webform_submission:serial]",
         "SUBMITTED_DATETIME": "[webform_submission:completed:prison_visit_booking_datetime]",
         "VISIT_ORDER_NO": "[webform_submission:values:visitor_order_number]",
         "INMATE_ID": "[webform_submission:values:prisoner_id]",

--- a/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
+++ b/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
@@ -89,6 +89,18 @@ class PrisonVisitBookingHandler extends WebformHandlerBase {
 
   /**
    * {@inheritdoc}
+   *
+   * If webform submissions are optionally enabled, we can prevent or
+   * alter the submission before insertion into the database to
+   * obfuscate sensitive data or remove it altogether.
+   */
+  public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
+    // For now, just delete the submission entirely!
+    $webform_submission->delete();
+  }
+
+  /**
+   * {@inheritdoc}
    * @throws \Exception
    */
   public function alterForm(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
@@ -378,13 +390,6 @@ class PrisonVisitBookingHandler extends WebformHandlerBase {
         }
       }
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
-    $webform_submission->delete();
   }
 
   /**

--- a/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
+++ b/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
@@ -799,7 +799,7 @@ class PrisonVisitBookingHandler extends WebformHandlerBase {
       // data is stored in cache and written to file.
 
       $file_uri = 'private://nidirect_webforms/prison_visit_slots_data.json';
-      $file_contents = @file_get_contents($file_uri);
+      $file_contents = file_exists($file_uri) ? file_get_contents($file_uri) : NULL;
 
       if (!empty($file_contents)) {
         $data = json_decode($file_contents, TRUE);

--- a/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
+++ b/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
@@ -671,13 +671,13 @@ class PrisonVisitBookingHandler extends WebformHandlerBase {
 
     // Early return when there is no valid booking reference.
     if (empty($this->bookingReference)) {
-      return ['error' => true];
+      return ['error' => TRUE];
     }
 
     // Return an error if there is no slot data.
     $data = $this->getData();
     if (!$data || empty($data['SLOTS'])) {
-      return ['error' => true];
+      return ['error' => TRUE];
     }
 
     // Get slots based on visit type. Return an error if none exist.
@@ -690,7 +690,7 @@ class PrisonVisitBookingHandler extends WebformHandlerBase {
       $slots = $data['SLOTS']['VIRTUAL'];
     }
     else {
-      return ['error' => true];
+      return ['error' => TRUE];
     }
 
     // Get available slots for specific prison and prisoner category.


### PR DESCRIPTION
Alter prison visit booking handler to retrieve all visit slots, face-to-face slots and virtual visit slots, from data posted from PRISM.  (Previously face-to-face slots came from PRISM data and virtual slots were notionally created from config)

Add a submission serial number to emailed form submission to help identify when a submission has not been received.