### PR TITLE
Shift front-end tooling out of appserver container into own

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -24,16 +24,8 @@ compose:
 services:
   appserver:
     scanner: false
-    environment:
-      # Set node compilation flag to allow arm64 and x86 chipset compilation.
-      CPPFLAGS: "-DPNG_ARM_NEON_OPT=0"
-      # node version set here will be used by the nvm installer script.
-      NODE_VERSION: 14.21.3
     build_as_root:
       - /app/.lando/scripts/appserver_build.sh
-    run:
-      - touch ~/.bashrc
-      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
     overrides:
       environment:
         # Support debugging CLI with XDEBUG.
@@ -58,9 +50,13 @@ services:
     portforward: true
     hogfrom:
       - appserver
-tooling:
   node:
-    service: appserver
+    type: 'node:14'
+    overrides:
+      environment:
+        # Set node compilation flag to allow arm64 and x86 chipset compilation.
+        CPPFLAGS: "-DPNG_ARM_NEON_OPT=0"
+tooling:
   xdebug-on:
     service: appserver
     description: Enable xdebug
@@ -71,8 +67,12 @@ tooling:
     description: Disable xdebug
     cmd: "rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && /etc/init.d/apache2 reload"
     user: root
+  npm:
+    service: node
+  node:
+    service: node
   yarn:
-    service: appserver
+    service: node
     cmd: yarn
   nightwatch:
     service: appserver


### PR DESCRIPTION
Makes it easier to isolate these tools in a versioned container rather than bundling them into the main appserver container. Also reduces the reliance on host installed tooling making this more re-usable across platforms and the wider team.

See https://github.com/dof-dss/nicsdru_unity/pull/1947#issue-2263719105 for evaluation details