### PR TITLE
D8NID-1669

### DIFF
--- a/web/modules/custom/nidirect_webforms/nidirect_webforms.module
+++ b/web/modules/custom/nidirect_webforms/nidirect_webforms.module
@@ -208,3 +208,30 @@ function nidirect_webforms_preprocess_form_element(&$variables) {
     $variables['label']['#title_display'] = 'before';
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function nidirect_webforms_preprocess_webform_confirmation(&$variables) {
+
+  // Fix for confirmation title not showing when "Page" is selected in
+  // confirmation settings.
+  // See https://www.drupal.org/project/webform/issues/3171108.
+
+  if ($variables['webform']->getSetting('confirmation_title')) {
+    $title = $variables['webform']->getSetting('confirmation_title');
+  }
+  elseif ($variables['source_entity']) {
+    $title = $variables['source_entity']->label();
+  }
+  else {
+    $title = $variables['webform']->label();
+  }
+
+  if ($variables['webform']->getSettings()['confirmation_type'] === 'page') {
+    $token_service = \Drupal::service('webform.token_manager');
+    $title = $token_service->replace($title, $variables['webform_submission'] ?: $variables['webform']);
+    $variables['title'] = $title;
+  }
+}
+

--- a/web/themes/custom/nicsdru_nidirect_theme/inc/preprocess.inc
+++ b/web/themes/custom/nicsdru_nidirect_theme/inc/preprocess.inc
@@ -750,29 +750,3 @@ function nicsdru_nidirect_theme_preprocess_views_view_rss(&$variables) {
     $variables['namespaces'] = new Attribute($style->namespaces);
   }
 }
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function nicsdru_nidirect_theme_preprocess_webform_confirmation(&$variables) {
-
-  // Fix for confirmation title not showing when "Page" is selected in
-  // confirmation settings.
-  // See https://www.drupal.org/project/webform/issues/3171108.
-
-  if ($variables['webform']->getSetting('confirmation_title')) {
-    $title = $variables['webform']->getSetting('confirmation_title');
-  }
-  elseif ($variables['source_entity']) {
-    $title = $variables['source_entity']->label();
-  }
-  else {
-    $title = $variables['webform']->label();
-  }
-
-  if ($variables['webform']->getSettings()['confirmation_type'] === 'page') {
-    $token_service = \Drupal::service('webform.token_manager');
-    $title = $token_service->replace($title, $variables['webform_submission'] ?: $variables['webform']);
-    $variables['title'] = $title;
-  }
-}

--- a/web/themes/custom/nicsdru_nidirect_theme/inc/preprocess.inc
+++ b/web/themes/custom/nicsdru_nidirect_theme/inc/preprocess.inc
@@ -750,3 +750,29 @@ function nicsdru_nidirect_theme_preprocess_views_view_rss(&$variables) {
     $variables['namespaces'] = new Attribute($style->namespaces);
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function nicsdru_nidirect_theme_preprocess_webform_confirmation(&$variables) {
+
+  // Fix for confirmation title not showing when "Page" is selected in
+  // confirmation settings.
+  // See https://www.drupal.org/project/webform/issues/3171108.
+
+  if ($variables['webform']->getSetting('confirmation_title')) {
+    $title = $variables['webform']->getSetting('confirmation_title');
+  }
+  elseif ($variables['source_entity']) {
+    $title = $variables['source_entity']->label();
+  }
+  else {
+    $title = $variables['webform']->label();
+  }
+
+  if ($variables['webform']->getSettings()['confirmation_type'] === 'page') {
+    $token_service = \Drupal::service('webform.token_manager');
+    $title = $token_service->replace($title, $variables['webform_submission'] ?: $variables['webform']);
+    $variables['title'] = $title;
+  }
+}

--- a/web/themes/custom/nicsdru_nidirect_theme/templates/form/webform-confirmation.html.twig
+++ b/web/themes/custom/nicsdru_nidirect_theme/templates/form/webform-confirmation.html.twig
@@ -16,11 +16,24 @@
 
 {{ attach_library('webform/webform.confirmation') }}
 
+{%
+  set back_classes = [
+  'btn',
+  'btn--large',
+  'btn--primary',
+  'btn--left',
+]
+%}
+
 {% if progress %}
   {{ progress }}
 {% endif %}
 
 <div{{ attributes.addClass(['webform-confirmation', 'ga-main']) }}>
+
+  {% if title %}
+    <h1 class="page-title">{{ title }}</h1>
+  {% endif %}
 
   {% if message %}
     <div class="webform-confirmation__message">{{ message }}</div>
@@ -28,7 +41,7 @@
 
   {% if back %}
   <div class="webform-confirmation__back">
-    <a class="btn btn--large btn--secondary btn--left" href="{{ back_url }}" rel="prev"{{ back_attributes }}>{{ back_label }}</a>
+    <a href="{{ back_url }}" rel="prev" data-self-ref="true" {{ back_attributes.addClass(back_classes) }}>{{ back_label }}</a>
   </div>
   {% endif %}
 


### PR DESCRIPTION
Fix for confirmation title not showing when "Page" is selected in webform confirmation settings.
See https://www.drupal.org/project/webform/issues/3171108.

(Also tweak to back button style shown on confirmation pages.)