### PR TITLE
Update view display config for contact, gp_practice, driving_instructor

### DIFF
--- a/config/sync/core.entity_form_display.node.contact.default.yml
+++ b/config/sync/core.entity_form_display.node.contact.default.yml
@@ -344,6 +344,22 @@ content:
         enable: true
         address_field: field_address
         geocoder: google_geocoding_api
+        geocoder_settings:
+          label: Address
+          description: 'Enter an address to be localized.'
+          autocomplete_min_length: 1
+          component_restrictions:
+            route: ''
+            country: UK
+            administrative_area: ''
+            locality: ''
+            postal_code: ''
+          boundary_restriction:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          region: gb
         sync_mode: auto
         button_position: LEFT_TOP
         direction: duplex
@@ -354,22 +370,6 @@ content:
           locality: false
           administrative-area: false
           postal-code: false
-        geocoder_settings:
-          label: Address
-          description: 'Enter an address to be localized.'
-          autocomplete_min_length: '1'
-          component_restrictions:
-            route: ''
-            locality: ''
-            administrative_area: ''
-            postal_code: ''
-            country: UK
-          boundary_restriction:
-            south: ''
-            west: ''
-            north: ''
-            east: ''
-          region: gb
   field_meta_tags:
     type: metatag_firehose
     weight: 11

--- a/config/sync/core.entity_form_display.node.gp_practice.default.yml
+++ b/config/sync/core.entity_form_display.node.gp_practice.default.yml
@@ -282,6 +282,16 @@ content:
         enable: true
         address_field: field_address
         geocoder: google_geocoding_api
+        sync_mode: auto
+        button_position: LEFT_TOP
+        direction: duplex
+        ignore:
+          organization: false
+          address-line1: false
+          address-line2: false
+          locality: false
+          administrative-area: false
+          postal-code: false
         settings:
           label: Address
           description: 'Enter an address to be localized.'
@@ -297,16 +307,6 @@ content:
             west: ''
             north: ''
             east: ''
-        sync_mode: auto
-        button_position: LEFT_TOP
-        direction: duplex
-        ignore:
-          organization: false
-          address-line1: false
-          address-line2: false
-          locality: false
-          administrative-area: false
-          postal-code: false
   field_meta_tags:
     type: metatag_firehose
     weight: 9

--- a/config/sync/core.entity_view_display.node.contact.diff.yml
+++ b/config/sync/core.entity_view_display.node.contact.diff.yml
@@ -30,7 +30,7 @@ dependencies:
     - layout_builder
     - link
     - metatag
-    - telephone_plus
+    - nidirect_contacts
     - text
     - user
 third_party_settings:
@@ -500,7 +500,7 @@ content:
     weight: 15
     region: content
   field_telephone:
-    type: telephone_plus_link
+    type: nidirect_telephone_link
     label: hidden
     settings:
       vcard: true

--- a/config/sync/core.entity_view_display.node.driving_instructor.default.yml
+++ b/config/sync/core.entity_view_display.node.driving_instructor.default.yml
@@ -17,8 +17,8 @@ dependencies:
   module:
     - link
     - metatag
+    - nidirect_contacts
     - origins_common
-    - telephone_plus
     - user
 id: node.driving_instructor.default
 targetEntityType: node
@@ -94,10 +94,9 @@ content:
     weight: 9
     region: content
   field_telephone:
-    type: telephone_plus
+    type: nidirect_telephone_link
     label: above
     settings:
-      link: true
       vcard: true
     third_party_settings: {  }
     weight: 10

--- a/config/sync/core.entity_view_display.node.driving_instructor.diff.yml
+++ b/config/sync/core.entity_view_display.node.driving_instructor.diff.yml
@@ -18,7 +18,7 @@ dependencies:
   module:
     - layout_builder
     - link
-    - telephone_plus
+    - nidirect_contacts
     - user
 third_party_settings:
   layout_builder:
@@ -94,10 +94,9 @@ content:
     weight: 6
     region: content
   field_telephone:
-    type: telephone_plus
+    type: nidirect_telephone_link
     label: above
     settings:
-      link: true
       vcard: true
     third_party_settings: {  }
     weight: 9

--- a/config/sync/core.entity_view_display.node.driving_instructor.full.yml
+++ b/config/sync/core.entity_view_display.node.driving_instructor.full.yml
@@ -20,8 +20,8 @@ dependencies:
     - layout_builder
     - link
     - metatag
+    - nidirect_contacts
     - origins_common
-    - telephone_plus
     - user
 third_party_settings:
   layout_builder:
@@ -30,9 +30,9 @@ third_party_settings:
   field_group:
     group_contact_info:
       children:
-        - field_telephone
         - field_email_address
         - field_link_url
+        - field_telephone
       label: 'Contact info'
       parent_name: ''
       region: content
@@ -100,10 +100,9 @@ content:
     weight: 4
     region: content
   field_telephone:
-    type: telephone_plus
+    type: nidirect_telephone_link
     label: above
     settings:
-      link: true
       vcard: true
     third_party_settings: {  }
     weight: 7

--- a/config/sync/core.entity_view_display.node.gp_practice.default.yml
+++ b/config/sync/core.entity_view_display.node.gp_practice.default.yml
@@ -22,7 +22,7 @@ dependencies:
   module:
     - address
     - geolocation
-    - telephone_plus
+    - nidirect_contacts
     - user
 id: node.gp_practice.default
 targetEntityType: node
@@ -374,10 +374,9 @@ content:
     weight: 4
     region: content
   field_telephone:
-    type: telephone_plus
+    type: nidirect_telephone_link
     label: above
     settings:
-      link: true
       vcard: true
     third_party_settings: {  }
     weight: 6

--- a/config/sync/core.entity_view_display.node.gp_practice.diff.yml
+++ b/config/sync/core.entity_view_display.node.gp_practice.diff.yml
@@ -27,8 +27,8 @@ dependencies:
     - layout_builder
     - link
     - metatag
+    - nidirect_contacts
     - options
-    - telephone_plus
     - user
 third_party_settings:
   layout_builder:
@@ -497,10 +497,9 @@ content:
     weight: 15
     region: content
   field_telephone:
-    type: telephone_plus
+    type: nidirect_telephone_link
     label: above
     settings:
-      link: true
       vcard: true
     third_party_settings: {  }
     weight: 16

--- a/config/sync/core.entity_view_display.node.gp_practice.full.yml
+++ b/config/sync/core.entity_view_display.node.gp_practice.full.yml
@@ -26,7 +26,7 @@ dependencies:
     - geolocation
     - layout_builder
     - link
-    - telephone_plus
+    - nidirect_contacts
     - user
 third_party_settings:
   layout_builder:
@@ -439,10 +439,9 @@ content:
     weight: 5
     region: content
   field_telephone:
-    type: telephone_plus
+    type: nidirect_telephone_link
     label: hidden
     settings:
-      link: true
       vcard: true
     third_party_settings: {  }
     weight: 7


### PR DESCRIPTION
Changed field_telephone to use "NIDirect Telephone Link" formatter as "Telephone Plus" formatter does not exist due to downgrade of telephone_plus module from 2.0@beta to 9.1.