### PR TITLE
D8NID-1693 fix for PHP Fatal error

### DIFF
--- a/web/modules/custom/nidirect_related_content/src/RelatedContentManager.php
+++ b/web/modules/custom/nidirect_related_content/src/RelatedContentManager.php
@@ -283,7 +283,9 @@ class RelatedContentManager {
     }
 
     // Sort the content list by title alphabetically.
-    array_multisort(array_column($this->content, 'title_sort'), SORT_ASC, $this->content);
+    uasort($this->content, function($a, $b) {
+      return strcmp($a['title_sort'], $b['title_sort']);
+    });
   }
 
   /**


### PR DESCRIPTION
When related content items gets to 40 or more, array_multisort generates a PHP Fatal error "Nesting level too deep".  Using uasort gets around this and produces same result.