### PR TITLE
Driving instructors teaser display hotfix

### DIFF
--- a/config/sync/core.entity_view_display.node.driving_instructor.teaser.yml
+++ b/config/sync/core.entity_view_display.node.driving_instructor.teaser.yml
@@ -135,7 +135,7 @@ content:
     region: content
   field_phone:
     type: telephone_plus
-    label: above
+    label: hidden
     settings:
       vcard: true
       link: true


### PR DESCRIPTION
Fixes issue where extra phone: label showing in addition to telephone plus item labels