### PR TITLE
Update eu_cookie_compliance.settings.yml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -216,6 +216,9 @@
             "drupal/easy_install": {
                 "Handle missing core version": "https://www.drupal.org/files/issues/2019-12-19/easy_install_core_version-3101883-0.patch"
             },
+            "drupal/eu_cookie_compliance": {
+                "JS Aggregation breaks in 10.1 when disabling other javascripts": "https://git.drupalcode.org/issue/eu_cookie_compliance-3412431/-/commit/3433c67b039e2319206ab68fd83a32cd161a99cb.diff"
+            },
             "drupal/filelog": {
                 "Circular refernce detected for service": "https://www.drupal.org/files/issues/2024-01-25/filelog_with_tests.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e5cd1483e506500447f67a37f4aed29",
+    "content-hash": "792e4303afd7dfe545d40824f3e0f805",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/sync/eu_cookie_compliance.settings.yml
+++ b/config/sync/eu_cookie_compliance.settings.yml
@@ -66,7 +66,9 @@ cookie_name: ''
 exclude_uid_1: true
 better_support_for_screen_readers: true
 method: opt_in
-disabled_javascripts: modules/contrib/google_tag/js/gtm.js
+disabled_javascripts: |-
+  modules/contrib/google_tag/js/gtag.js||google_tag/gtag
+  modules/contrib/google_tag/js/gtm.js||google_tag/gtm
 automatic_cookies_removal: true
 allowed_cookies: ''
 consent_storage_method: do_not_store

--- a/config/sync/eu_cookie_compliance.settings.yml
+++ b/config/sync/eu_cookie_compliance.settings.yml
@@ -5,8 +5,8 @@ uuid: 4aeec51b-9eb4-4468-81c6-0c1d8ac9e55a
 popup_enabled: true
 popup_clicking_confirmation: false
 popup_scrolling_confirmation: false
-eu_only: null
-eu_only_js: null
+eu_only: false
+eu_only_js: false
 popup_position: false
 fixed_top_position: false
 popup_info:
@@ -57,6 +57,7 @@ set_cookie_session_zero_on_disagree: 0
 cookie_lifetime: 365
 use_mobile_message: false
 use_bare_css: true
+use_olivero_css: false
 disagree_do_not_show_popup: false
 reload_page: false
 reload_options: null
@@ -65,7 +66,7 @@ cookie_name: ''
 exclude_uid_1: true
 better_support_for_screen_readers: true
 method: opt_in
-disabled_javascripts: 'public://google_tag/nidirect/google_tag.script.js'
+disabled_javascripts: modules/contrib/google_tag/js/gtm.js
 automatic_cookies_removal: true
 allowed_cookies: ''
 consent_storage_method: do_not_store
@@ -97,6 +98,10 @@ cookie_categories: ''
 fix_first_cookie_category: true
 select_all_categories_by_default: false
 accessibility_focus: false
+close_button_action: close_banner
+reject_button_label: ''
+reject_button_enabled: false
+close_button_enabled: false
 dependencies:
   config:
     - filter.format.basic_html


### PR DESCRIPTION
Following changes to Google Tag module, the EUCC module now needs to disable 
modules/contrib/google_tag/js/gtm.js instead of public://google_tag/nidirect/google_tag.script.js