### PR TITLE
Hotfix for GP Practice search WSOD

### DIFF
--- a/web/modules/custom/nidirect_gp/src/Controller/GpSearchController.php
+++ b/web/modules/custom/nidirect_gp/src/Controller/GpSearchController.php
@@ -367,7 +367,7 @@ class GpSearchController extends ControllerBase {
       $reverse = $nominatim->newReverse()->latlon($latitude, $longitude);
       $result = $nominatim->find($reverse);
     }
-    catch (NominatimException $e) {
+    catch (\Exception $e) {
       $this->getLogger('nidirect_gp')->error($e);
       return $locality;
     }


### PR DESCRIPTION
Catch all possible exceptions when doing reverse location lookup in GpSearchController.php