### PR TITLE
D8NID-1699 Fix Mysterious Missing Breadcrumb

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -190,8 +190,3 @@ crons:
     commands:
       start: '/bin/bash /app/cronjob.sh'
     shutdown_timeout: 290
-  # Workaround for the "mysterious disappearing breadcrumb" saga.
-  breadcrumb-reveal-thyself:
-    spec: '0 5 * * *'
-    commands:
-      start: 'cd web ; drush cc render'

--- a/web/modules/custom/nidirect_breadcrumbs/src/LandingPageBreadcrumb.php
+++ b/web/modules/custom/nidirect_breadcrumbs/src/LandingPageBreadcrumb.php
@@ -85,6 +85,8 @@ class LandingPageBreadcrumb implements BreadcrumbBuilderInterface {
   public function build(RouteMatchInterface $route_match) {
 
     $breadcrumb = new Breadcrumb();
+    $links = [];
+    $cache_tags = [];
 
     $route_name = $route_match->getRouteName();
 
@@ -124,18 +126,17 @@ class LandingPageBreadcrumb implements BreadcrumbBuilderInterface {
             $cache_tags[] = 'taxonomy_term:' . $term->id();
           }
         }
-
-        // Assemble a new breadcrumb object, add the links and set
-        // a URL path cache context so it varies as you move from one
-        // set of content to another.
-        $breadcrumb = new Breadcrumb();
-        $breadcrumb->setLinks($links);
-        $breadcrumb->addCacheContexts(['url.path']);
-
-        if (!empty($cache_tags)) {
-          $breadcrumb->addCacheTags($cache_tags);
-        }
       }
+    }
+
+    // Assemble breadcrumb, add the links and set
+    // a URL path cache context so it varies as you move from one
+    // set of content to another.
+    $breadcrumb->setLinks($links);
+    $breadcrumb->addCacheContexts(['url.path']);
+
+    if (!empty($cache_tags)) {
+      $breadcrumb->addCacheTags($cache_tags);
     }
 
     return $breadcrumb;

--- a/web/modules/custom/nidirect_breadcrumbs/src/NodeThemesBreadcrumb.php
+++ b/web/modules/custom/nidirect_breadcrumbs/src/NodeThemesBreadcrumb.php
@@ -130,6 +130,10 @@ class NodeThemesBreadcrumb implements BreadcrumbBuilderInterface {
     // Fetch the node or preview node object.
     $node = $route_match->getParameter('node') ?? $route_match->getParameter('node_preview');
 
+    // Fix mysterious missing breadcrumb issue (D8NID-1699, D8NID-1542).
+    // Ensure url.path cache context set prior to early return.
+    $breadcrumb->addCacheContexts(['url.path']);
+
     // Return early if it's a supporting/secondary node type:
     // feature/featured_content_list.
     if (preg_match('/^feature/', $node->getType())) {
@@ -180,7 +184,7 @@ class NodeThemesBreadcrumb implements BreadcrumbBuilderInterface {
     // a URL path cache context so it varies as you move from one
     // set of content to another.
     $breadcrumb->setLinks($links);
-    $breadcrumb->addCacheContexts(['url.path']);
+
 
     // Prevent the caching of breadcrumbs on updated content and node previews.
     if ($route_match->getRouteName() === 'entity.node.preview') {

--- a/web/modules/custom/nidirect_breadcrumbs/src/NodeThemesBreadcrumb.php
+++ b/web/modules/custom/nidirect_breadcrumbs/src/NodeThemesBreadcrumb.php
@@ -185,7 +185,6 @@ class NodeThemesBreadcrumb implements BreadcrumbBuilderInterface {
     // set of content to another.
     $breadcrumb->setLinks($links);
 
-
     // Prevent the caching of breadcrumbs on updated content and node previews.
     if ($route_match->getRouteName() === 'entity.node.preview') {
       // Node previews don't have a Node ID we can reference but instead use a


### PR DESCRIPTION
After many months of disappearing breadcrumb trails, it turns out that an early return in NodeThemesBreadcrumb.php was causing (I think) an empty breadcrumb to be cached with no cache context leading to all nodes then showing an empty breadcrumb after a user views a feature/featured_content_list.