### PR TITLE
Give supervisors quick_publish permission

### DIFF
--- a/config/sync/user.role.supervisor_user.yml
+++ b/config/sync/user.role.supervisor_user.yml
@@ -150,6 +150,7 @@ permissions:
   - 'use nics_editorial_workflow transition create_new_draft'
   - 'use nics_editorial_workflow transition draft_of_published'
   - 'use nics_editorial_workflow transition publish'
+  - 'use nics_editorial_workflow transition quick_publish'
   - 'use nics_editorial_workflow transition reject'
   - 'use nics_editorial_workflow transition restore'
   - 'use nics_editorial_workflow transition restore_to_draft'


### PR DESCRIPTION
Supervisors must have have quick_publish permission to add draft pages to a published book (see https://www.drupal.org/project/book/issues/2918537#comment-15799171)