### PR TITLE
D8NID-1826 Prison Visits exception error fix

### DIFF
--- a/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
+++ b/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php
@@ -1142,10 +1142,15 @@ class PrisonVisitBookingHandler extends WebformHandlerBase {
 
     $booking_ref = !empty($form_state->getValue('visitor_order_number')) ? $form_state->getValue('visitor_order_number') : NULL;
 
-    $this->processVisitBookingReference($booking_ref, $form, $form_state, $webform_submission);
+    if ($booking_ref) {
+      $this->processVisitBookingReference($booking_ref, $form, $form_state, $webform_submission);
 
-    if (!empty($this->bookingReference['error_status'])) {
-      $form_state->setErrorByName('visitor_order_number', $this->bookingReference['error_status_msg']);
+      if (!empty($this->bookingReference['error_status'])) {
+        $form_state->setErrorByName('visitor_order_number', $this->bookingReference['error_status_msg']);
+      }
+    }
+    else {
+      $form_state->setErrorByName('visitor_order_number', $this->t('Visit reference number is required'));
     }
   }
 


### PR DESCRIPTION
Fix for Uncaught PHP Exception TypeError: "Drupal\nidirect_webforms\Plugin\WebformHandler\PrisonVisitBookingHandler::processVisitBookingReference(): Argument #1 ($booking_ref) must be of type string, null given, called in /app/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php on line 1145" at /app/web/modules/custom/nidirect_webforms/src/Plugin/WebformHandler/PrisonVisitBookingHandler.php line 922

