### PR TITLE
Uninstall redundant module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -113,7 +113,6 @@ module:
   moderation_sidebar: 0
   mysql: 0
   nidirect_breadcrumbs: 0
-  nidirect_campaign_importer: 0
   nidirect_cold_weather_payments: 0
   nidirect_common: 0
   nidirect_contacts: 0


### PR DESCRIPTION
Uninstall module(s) ahead of PR to remove the files at a later deployment.