### PR TITLE
D8NID-1906  Contact node form edit adjustments 

### DIFF
--- a/config/sync/core.entity_form_display.node.contact.default.yml
+++ b/config/sync/core.entity_form_display.node.contact.default.yml
@@ -29,7 +29,8 @@ dependencies:
     - content_moderation
     - datetime
     - field_group
-    - geolocation
+    - geolocation_address
+    - geolocation_google_maps
     - link
     - linkit
     - metatag
@@ -43,40 +44,61 @@ third_party_settings:
     group_general:
       children:
         - field_supplementary_contact
-        - field_summary
-        - body
-        - field_contact_additional_info
-      label: General
-      region: content
-      parent_name: ''
-      weight: 8
-      format_type: details
-      format_settings:
-        classes: ''
-        id: ''
-        open: true
-        required_fields: true
-    group_detail:
-      children:
         - field_contact_category
         - field_contact_group
-        - field_address
-        - field_location
-        - field_email_address
-        - field_phone
-        - field_contact_website
-        - field_show_external_link
-        - field_contact_hours
         - field_site_themes
-      label: Detail
+        - field_summary
+        - body
+      label: General
       region: content
       parent_name: ''
       weight: 9
       format_type: details
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
+        label_as_html: false
+        open: false
+        description: ''
+        required_fields: true
+    group_detail:
+      children:
+        - field_address
+        - field_location
+        - field_email_address
+        - field_phone
+        - field_contact_website
+      label: 'Contact information'
+      region: content
+      parent_name: ''
+      weight: 10
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
         open: true
+        description: ''
+        required_fields: true
+    group_additional_information:
+      children:
+        - field_contact_hours
+        - field_contact_additional_info
+        - field_related_info
+      label: 'Additional information'
+      region: content
+      parent_name: ''
+      weight: 11
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: false
+        description: ''
         required_fields: true
 id: node.contact.default
 targetEntityType: node
@@ -85,7 +107,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 5
+    weight: 8
     region: content
     settings:
       rows: 9
@@ -95,20 +117,20 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_address:
     type: address_default
-    weight: 3
+    weight: 9
     region: content
     settings:
       wrapper_type: details
     third_party_settings: {  }
   field_contact_additional_info:
     type: text_textarea
-    weight: 6
+    weight: 15
     region: content
     settings:
       rows: 5
@@ -116,13 +138,13 @@ content:
     third_party_settings: {  }
   field_contact_category:
     type: options_select
-    weight: 1
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_contact_group:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -132,7 +154,7 @@ content:
     third_party_settings: {  }
   field_contact_hours:
     type: text_textarea
-    weight: 9
+    weight: 14
     region: content
     settings:
       rows: 5
@@ -140,7 +162,7 @@ content:
     third_party_settings: {  }
   field_contact_website:
     type: link_default
-    weight: 7
+    weight: 13
     region: content
     settings:
       placeholder_url: ''
@@ -148,21 +170,351 @@ content:
     third_party_settings: {  }
   field_email_address:
     type: email_default
-    weight: 5
+    weight: 11
     region: content
     settings:
       placeholder: ''
       size: 60
     third_party_settings: {  }
   field_location:
-    type: geolocation_html5
-    weight: 4
+    type: geolocation_googlegeocoder
+    weight: 10
     region: content
-    settings: {  }
-    third_party_settings: {  }
+    settings:
+      auto_client_location: ''
+      auto_client_location_marker: '0'
+      allow_override_map_settings: 0
+      hide_textfield_form: false
+      centre:
+        fit_bounds:
+          enable: true
+          weight: 0
+          settings:
+            reset_zoom: false
+            min_zoom: 12
+          map_center_id: fit_bounds
+        fixed_value:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: fixed_value
+            latitude: null
+            longitude: null
+          map_center_id: location_plugins
+        ipstack:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: ipstack
+            access_key: ''
+          map_center_id: location_plugins
+        client_location:
+          enable: false
+          weight: 0
+          map_center_id: client_location
+        fixed_boundaries:
+          enable: false
+          weight: 0
+          settings:
+            south: ''
+            west: ''
+            north: '0'
+            east: ''
+          map_center_id: fixed_boundaries
+      google_map_settings:
+        map_features:
+          control_geocoder:
+            weight: -100
+            settings:
+              position: TOP_LEFT
+              geocoder: google_geocoding_api
+              settings:
+                label: Address
+                description: 'Enter address'
+                autocomplete_min_length: 1
+                component_restrictions:
+                  route: ''
+                  country: ''
+                  administrative_area: ''
+                  locality: ''
+                  postal_code: ''
+                boundary_restriction:
+                  south: ''
+                  west: ''
+                  north: ''
+                  east: ''
+                region: ''
+            enabled: true
+          google_maps_layer_bicycling:
+            weight: 0
+            enabled: false
+          client_location_indicator:
+            weight: 0
+            enabled: false
+          context_popup:
+            weight: 0
+            settings:
+              content:
+                value: ''
+                format: basic_html
+            enabled: false
+          drawing:
+            weight: 0
+            settings:
+              polyline: false
+              strokeColor: '#FF0000'
+              strokeOpacity: '0.8'
+              strokeWeight: '2'
+              geodesic: false
+              polygon: false
+              fillColor: '#FF0000'
+              fillOpacity: '0.35'
+            enabled: false
+          geolocation_google_maps_control_directions:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+              origin_source: exposed
+              origin_static_value: ''
+              destination_source: exposed
+              destination_static_value: ''
+              travel_mode: exposed
+              directions_container: below
+              directions_container_custom_id: ''
+            enabled: false
+          map_disable_tilt:
+            weight: 0
+            enabled: false
+          map_disable_poi:
+            weight: 0
+            enabled: false
+          map_disable_user_interaction:
+            weight: 0
+            enabled: false
+          geolocation_shapes:
+            weight: 0
+            settings:
+              remove_markers: false
+              polyline: true
+              polyline_title: ''
+              strokeColor: '#FF0000'
+              strokeOpacity: 0.8
+              strokeWidth: '2'
+              polygon: false
+              polygon_title: ''
+              fillColor: '#FF0000'
+              fillOpacity: 0.35
+            enabled: false
+          control_fullscreen:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+            enabled: false
+          control_loading_indicator:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+              loading_label: Loading
+            enabled: false
+          control_locate:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+            enabled: false
+          control_maptype:
+            weight: 0
+            settings:
+              position: RIGHT_TOP
+              behavior: default
+              style: DROPDOWN_MENU
+            enabled: true
+          control_recenter:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+            enabled: false
+          control_rotate:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+            enabled: false
+          control_streetview:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+            enabled: false
+          control_zoom:
+            weight: 0
+            settings:
+              position: BOTTOM_RIGHT
+              behavior: default
+              style: SMALL
+            enabled: true
+          map_restriction:
+            weight: 0
+            settings:
+              north: ''
+              south: ''
+              east: ''
+              west: ''
+              strict: true
+            enabled: false
+          map_type_style:
+            weight: 0
+            settings:
+              style: '[]'
+            enabled: false
+          marker_clusterer:
+            weight: 0
+            settings:
+              image_path: ''
+              styles: ''
+              max_zoom: 15
+              minimum_cluster_size: 2
+              zoom_on_click: true
+              average_center: false
+              grid_size: 60
+            enabled: false
+          marker_icon:
+            weight: 0
+            settings:
+              marker_icon_path: ''
+              anchor:
+                x: 0
+                'y': 0
+              origin:
+                x: 0
+                'y': 0
+              label_origin:
+                x: 0
+                'y': 0
+              size:
+                width: null
+                height: null
+              scaled_size:
+                width: null
+                height: null
+            enabled: false
+          marker_infobubble:
+            weight: 0
+            settings:
+              close_other: 1
+              close_button: 0
+              close_button_src: ''
+              shadow_style: 0
+              padding: 10
+              border_radius: 8
+              border_width: 2
+              border_color: '#039be5'
+              background_color: '#fff'
+              min_width: null
+              max_width: 550
+              min_height: null
+              max_height: null
+              arrow_style: 2
+              arrow_position: 30
+              arrow_size: 10
+            enabled: false
+          marker_infowindow:
+            weight: 0
+            settings:
+              info_window_solitary: true
+              disable_auto_pan: true
+              info_auto_display: false
+              max_width: null
+            enabled: false
+          marker_label:
+            weight: 0
+            settings:
+              color: ''
+              font_family: ''
+              font_size: ''
+              font_weight: ''
+            enabled: false
+          marker_opacity:
+            weight: 0
+            settings:
+              opacity: 1.0
+            enabled: false
+          geolocation_marker_scroll_to_id:
+            weight: 0
+            settings:
+              scroll_target_id: ''
+            enabled: false
+          marker_zoom_to_animate:
+            weight: 0
+            settings:
+              marker_zoom_anchor_id: ''
+            enabled: false
+          spiderfying:
+            weight: 0
+            settings:
+              spiderfiable_marker_path: /modules/contrib/geolocation/modules/geolocation_google_maps/images/marker-plus.svg
+              markersWontMove: true
+              markersWontHide: false
+              keepSpiderfied: true
+              ignoreMapClick: false
+              nearbyDistance: 20
+              circleSpiralSwitchover: 9
+              circleFootSeparation: 23
+              spiralFootSeparation: 26
+              spiralLengthStart: 11
+              spiralLengthFactor: 4
+              legWeight: 1.5
+              spiralIconWidth: 23
+              spiralIconHeight: 32
+            enabled: false
+          google_maps_layer_traffic:
+            weight: 0
+            enabled: false
+          google_maps_layer_transit:
+            weight: 0
+            enabled: false
+        type: ROADMAP
+        zoom: 10
+        minZoom: 0
+        maxZoom: 20
+        height: 400px
+        width: 100%
+        gestureHandling: auto
+    third_party_settings:
+      geolocation_address:
+        enable: true
+        address_field: field_address
+        geocoder: google_geocoding_api
+        settings:
+          label: Address
+          description: 'Enter an address to be localized.'
+          autocomplete_min_length: 3
+          component_restrictions:
+            route: ''
+            country: ''
+            administrative_area: ''
+            locality: ''
+            postal_code: ''
+          boundary_restriction:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          region: ''
+        sync_mode: auto
+        button_position: LEFT_TOP
+        direction: one_way
+        ignore:
+          organization: false
+          address-line1: false
+          address-line2: false
+          locality: false
+          administrative-area: false
+          postal-code: false
   field_meta_tags:
     type: metatag_firehose
-    weight: 11
+    weight: 13
     region: content
     settings:
       sidebar: true
@@ -170,13 +522,13 @@ content:
     third_party_settings: {  }
   field_next_audit_due:
     type: datetime_default
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   field_phone:
     type: telephone_plus_widget
-    weight: 6
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -192,7 +544,7 @@ content:
     third_party_settings: {  }
   field_search_elevation:
     type: search_api_best_bets_widget
-    weight: 17
+    weight: 18
     region: content
     settings:
       elevate_label: 'Elevate query'
@@ -205,14 +557,14 @@ content:
     third_party_settings: {  }
   field_show_external_link:
     type: boolean_checkbox
-    weight: 8
+    weight: 1
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_site_themes:
     type: options_shs
-    weight: 10
+    weight: 6
     region: content
     settings:
       display_node_count: false
@@ -222,7 +574,7 @@ content:
     third_party_settings: {  }
   field_summary:
     type: string_textarea
-    weight: 4
+    weight: 7
     region: content
     settings:
       rows: 5
@@ -243,26 +595,26 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 1
+    weight: 2
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 4
+    weight: 5
     region: content
     settings:
       display_label: true
@@ -285,20 +637,20 @@ content:
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 5
+    weight: 6
     region: content
     settings:
       display_label: true
@@ -313,7 +665,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
@@ -334,7 +686,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.contact.default.yml
+++ b/config/sync/core.entity_form_display.node.contact.default.yml
@@ -229,8 +229,8 @@ content:
               position: TOP_LEFT
               geocoder: google_geocoding_api
               settings:
-                label: Address
-                description: 'Enter address'
+                label: 'Enter address'
+                description: ''
                 autocomplete_min_length: 1
                 component_restrictions:
                   route: ''
@@ -483,7 +483,7 @@ content:
         gestureHandling: auto
     third_party_settings:
       geolocation_address:
-        enable: true
+        enable: false
         address_field: field_address
         geocoder: google_geocoding_api
         settings:

--- a/config/sync/core.entity_view_display.node.contact.default.yml
+++ b/config/sync/core.entity_view_display.node.contact.default.yml
@@ -70,23 +70,9 @@ content:
           enable: true
           weight: -101
           settings:
+            reset_zoom: false
             min_zoom: 12
           map_center_id: fit_bounds
-        fit_shapes:
-          enable: false
-          weight: 0
-          settings:
-            min_zoom: null
-          map_center_id: fit_shapes
-        fixed_boundaries:
-          enable: false
-          weight: 0
-          settings:
-            south: ''
-            west: ''
-            north: ''
-            east: ''
-          map_center_id: fixed_boundaries
         fixed_value:
           enable: false
           weight: 0
@@ -102,6 +88,19 @@ content:
             location_option_id: ipstack
             access_key: ''
           map_center_id: location_plugins
+        client_location:
+          enable: false
+          weight: 0
+          map_center_id: client_location
+        fixed_boundaries:
+          enable: false
+          weight: 0
+          settings:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          map_center_id: fixed_boundaries
       map_provider_id: google_maps
       map_provider_settings:
         map_features:
@@ -118,10 +117,23 @@ content:
                 value: ''
                 format: basic_html
             enabled: false
+          drawing:
+            weight: 0
+            settings:
+              polyline: false
+              strokeColor: '#FF0000'
+              strokeOpacity: '0.8'
+              strokeWeight: '2'
+              geodesic: false
+              polygon: false
+              fillColor: '#FF0000'
+              fillOpacity: '0.35'
+            enabled: false
           geolocation_google_maps_control_directions:
             weight: 0
             settings:
               position: RIGHT_CENTER
+              behavior: default
               origin_source: exposed
               origin_static_value: ''
               destination_source: exposed
@@ -157,13 +169,14 @@ content:
             weight: 0
             settings:
               position: RIGHT_CENTER
+              behavior: default
             enabled: false
           control_geocoder:
             weight: 0
             settings:
               position: TOP_LEFT
               geocoder: google_geocoding_api
-              geocoder_settings:
+              settings:
                 label: Address
                 description: 'Enter an address to be localized.'
                 autocomplete_min_length: 1
@@ -178,7 +191,7 @@ content:
                   west: ''
                   north: ''
                   east: ''
-                region: gb
+                region: ''
             enabled: false
           control_loading_indicator:
             weight: 0
@@ -194,7 +207,8 @@ content:
           control_maptype:
             weight: 0
             settings:
-              position: RIGHT_BOTTOM
+              position: RIGHT_TOP
+              behavior: default
               style: DEFAULT
             enabled: true
           control_recenter:
@@ -206,21 +220,20 @@ content:
             weight: 0
             settings:
               position: RIGHT_CENTER
+              behavior: default
             enabled: false
           control_streetview:
             weight: 0
             settings:
               position: RIGHT_CENTER
-            enabled: false
-          control_tile_layers:
-            weight: 0
-            settings:
-              position: TOP_LEFT
+              behavior: default
             enabled: false
           control_zoom:
             weight: 0
             settings:
-              position: RIGHT_CENTER
+              position: BOTTOM_RIGHT
+              behavior: default
+              style: LARGE
             enabled: true
           map_restriction:
             weight: 0
@@ -236,6 +249,106 @@ content:
             settings:
               style: '[]'
             enabled: false
+          marker_clusterer:
+            weight: 0
+            settings:
+              image_path: ''
+              styles: ''
+              max_zoom: 15
+              minimum_cluster_size: 2
+              zoom_on_click: true
+              average_center: false
+              grid_size: 60
+            enabled: false
+          marker_icon:
+            weight: 0
+            settings:
+              marker_icon_path: ''
+              anchor:
+                x: 0
+                'y': 0
+              origin:
+                x: 0
+                'y': 0
+              label_origin:
+                x: 0
+                'y': 0
+              size:
+                width: null
+                height: null
+              scaled_size:
+                width: null
+                height: null
+            enabled: false
+          marker_infobubble:
+            weight: 0
+            settings:
+              close_other: 1
+              close_button: 0
+              close_button_src: ''
+              shadow_style: 0
+              padding: 10
+              border_radius: 8
+              border_width: 2
+              border_color: '#039be5'
+              background_color: '#fff'
+              min_width: null
+              max_width: 550
+              min_height: null
+              max_height: null
+              arrow_style: 2
+              arrow_position: 30
+              arrow_size: 10
+            enabled: false
+          marker_infowindow:
+            weight: 0
+            settings:
+              info_window_solitary: true
+              disable_auto_pan: true
+              info_auto_display: false
+              max_width: null
+            enabled: true
+          marker_label:
+            weight: 0
+            settings:
+              color: ''
+              font_family: ''
+              font_size: ''
+              font_weight: ''
+            enabled: false
+          marker_opacity:
+            weight: 0
+            settings:
+              opacity: 1.0
+            enabled: false
+          geolocation_marker_scroll_to_id:
+            weight: 0
+            settings:
+              scroll_target_id: ''
+            enabled: false
+          marker_zoom_to_animate:
+            weight: 0
+            settings:
+              marker_zoom_anchor_id: ''
+            enabled: false
+          spiderfying:
+            weight: 0
+            settings:
+              spiderfiable_marker_path: /modules/contrib/geolocation/modules/geolocation_google_maps/images/marker-plus.svg
+              markersWontMove: true
+              markersWontHide: false
+              keepSpiderfied: true
+              ignoreMapClick: false
+              nearbyDistance: 20
+              circleSpiralSwitchover: 9
+              circleFootSeparation: 23
+              spiralFootSeparation: 26
+              spiralLengthStart: 11
+              spiralLengthFactor: 4
+              legWeight: 1.5
+              spiralIconWidth: 23
+              spiralIconHeight: 32
+            enabled: false
           google_maps_layer_traffic:
             weight: 0
             enabled: false
@@ -249,126 +362,6 @@ content:
         height: 400px
         width: 100%
         gestureHandling: auto
-        conditional_initialization: viewport
-        conditional_description: 'Clicking this button will embed a map.'
-        conditional_label: 'Show map'
-        conditional_viewport_threshold: 0.8
-        data_layers:
-          'geolocation_default_layer:default':
-            enabled: true
-            weight: -1
-            settings:
-              features:
-                marker_clusterer:
-                  enabled: false
-                  weight: 0
-                marker_icon:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    marker_icon_path: ''
-                    anchor:
-                      x: 0
-                      'y': 0
-                    origin:
-                      x: 0
-                      'y': 0
-                    label_origin:
-                      x: 0
-                      'y': 0
-                    size:
-                      width: null
-                      height: null
-                    scaled_size:
-                      width: null
-                      height: null
-                marker_infobubble:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    close_other: 1
-                    close_button: 0
-                    close_button_src: ''
-                    shadow_style: 0
-                    padding: 10
-                    border_radius: 8
-                    border_width: 2
-                    border_color: '#039be5'
-                    background_color: '#fff'
-                    min_width: null
-                    max_width: 550
-                    min_height: null
-                    max_height: null
-                    arrow_style: 2
-                    arrow_position: 30
-                    arrow_size: 10
-                marker_infowindow:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    info_window_solitary: true
-                    disable_auto_pan: true
-                    info_auto_display: false
-                    max_width: null
-                marker_label:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    color: ''
-                    font_family: ''
-                    font_size: ''
-                    font_weight: ''
-                marker_opacity:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    opacity: 1.0
-                marker_zoom_by_anchor:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    marker_zoom_anchor_id: ''
-                spiderfying:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    spiderfiable_marker_path: /modules/contrib/geolocation/modules/geolocation_google_maps/images/marker-plus.svg
-                    markersWontMove: true
-                    markersWontHide: false
-                    keepSpiderfied: true
-                    ignoreMapClick: false
-                    nearbyDistance: 20
-                    circleSpiralSwitchover: 9
-                    circleFootSeparation: 23
-                    spiralFootSeparation: 26
-                    spiralLengthStart: 11
-                    spiralLengthFactor: 4
-                    legWeight: 1.5
-                    spiralIconWidth: 23
-                    spiralIconHeight: 32
-        tile_layers:
-          geolocation_tile_thunderforest:
-            settings:
-              apikey: ''
-            layers:
-              'geolocation_tile_thunderforest:cycle':
-                enabled: 0
-              'geolocation_tile_thunderforest:transport':
-                enabled: 0
-              'geolocation_tile_thunderforest:transport-dark':
-                enabled: 0
-              'geolocation_tile_thunderforest:spinal-map':
-                enabled: 0
-              'geolocation_tile_thunderforest:landscape':
-                enabled: 0
-              'geolocation_tile_thunderforest:outdoors':
-                enabled: 0
-              'geolocation_tile_thunderforest:pioneer':
-                enabled: 0
-              'geolocation_tile_thunderforest:mobile-atlas':
-                enabled: 0
-              'geolocation_tile_thunderforest:neighbourhood':
-                enabled: 0
       data_provider_settings: {  }
     third_party_settings: {  }
     weight: 6

--- a/config/sync/core.entity_view_display.node.contact.external_link.yml
+++ b/config/sync/core.entity_view_display.node.contact.external_link.yml
@@ -1,0 +1,88 @@
+uuid: 30bd6419-8619-4024-b4c5-07a3bbbf9253
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.external_link
+    - field.field.node.contact.body
+    - field.field.node.contact.field_address
+    - field.field.node.contact.field_contact_additional_info
+    - field.field.node.contact.field_contact_category
+    - field.field.node.contact.field_contact_group
+    - field.field.node.contact.field_contact_hours
+    - field.field.node.contact.field_contact_website
+    - field.field.node.contact.field_email_address
+    - field.field.node.contact.field_location
+    - field.field.node.contact.field_meta_tags
+    - field.field.node.contact.field_next_audit_due
+    - field.field.node.contact.field_phone
+    - field.field.node.contact.field_related_info
+    - field.field.node.contact.field_search_elevation
+    - field.field.node.contact.field_show_external_link
+    - field.field.node.contact.field_site_themes
+    - field.field.node.contact.field_summary
+    - field.field.node.contact.field_supplementary_contact
+    - field.field.node.contact.field_telephone
+    - node.type.contact
+  module:
+    - layout_builder
+    - link
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.contact.external_link
+targetEntityType: node
+bundle: contact
+mode: external_link
+content:
+  field_contact_website:
+    type: link
+    label: inline
+    settings:
+      trim_length: 80
+      url_only: true
+      url_plain: false
+      rel: '0'
+      target: _blank
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_show_external_link:
+    type: boolean
+    label: inline
+    settings:
+      format: enabled-disabled
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  body: true
+  content_moderation_control: true
+  field_address: true
+  field_contact_additional_info: true
+  field_contact_category: true
+  field_contact_group: true
+  field_contact_hours: true
+  field_email_address: true
+  field_location: true
+  field_meta_tags: true
+  field_next_audit_due: true
+  field_phone: true
+  field_related_info: true
+  field_search_elevation: true
+  field_site_themes: true
+  field_summary: true
+  field_supplementary_contact: true
+  field_telephone: true
+  langcode: true
+  search_api_excerpt: true
+  toc_display: true

--- a/config/sync/core.entity_view_display.node.contact.full.yml
+++ b/config/sync/core.entity_view_display.node.contact.full.yml
@@ -130,23 +130,9 @@ content:
           enable: true
           weight: -101
           settings:
+            reset_zoom: false
             min_zoom: 12
           map_center_id: fit_bounds
-        fit_shapes:
-          enable: false
-          weight: 0
-          settings:
-            min_zoom: null
-          map_center_id: fit_shapes
-        fixed_boundaries:
-          enable: false
-          weight: 0
-          settings:
-            south: ''
-            west: ''
-            north: ''
-            east: ''
-          map_center_id: fixed_boundaries
         fixed_value:
           enable: false
           weight: 0
@@ -162,6 +148,19 @@ content:
             location_option_id: ipstack
             access_key: ''
           map_center_id: location_plugins
+        client_location:
+          enable: false
+          weight: 0
+          map_center_id: client_location
+        fixed_boundaries:
+          enable: false
+          weight: 0
+          settings:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          map_center_id: fixed_boundaries
       map_provider_id: google_maps
       map_provider_settings:
         map_features:
@@ -178,10 +177,23 @@ content:
                 value: ''
                 format: basic_html
             enabled: false
+          drawing:
+            weight: 0
+            settings:
+              polyline: false
+              strokeColor: '#FF0000'
+              strokeOpacity: '0.8'
+              strokeWeight: '2'
+              geodesic: false
+              polygon: false
+              fillColor: '#FF0000'
+              fillOpacity: '0.35'
+            enabled: false
           geolocation_google_maps_control_directions:
             weight: 0
             settings:
               position: RIGHT_CENTER
+              behavior: default
               origin_source: exposed
               origin_static_value: ''
               destination_source: exposed
@@ -217,13 +229,14 @@ content:
             weight: 0
             settings:
               position: RIGHT_CENTER
+              behavior: default
             enabled: false
           control_geocoder:
             weight: 0
             settings:
               position: TOP_LEFT
               geocoder: google_geocoding_api
-              geocoder_settings:
+              settings:
                 label: Address
                 description: 'Enter an address to be localized.'
                 autocomplete_min_length: 1
@@ -238,7 +251,7 @@ content:
                   west: ''
                   north: ''
                   east: ''
-                region: gb
+                region: ''
             enabled: false
           control_loading_indicator:
             weight: 0
@@ -254,7 +267,8 @@ content:
           control_maptype:
             weight: 0
             settings:
-              position: RIGHT_BOTTOM
+              position: TOP_RIGHT
+              behavior: default
               style: DEFAULT
             enabled: true
           control_recenter:
@@ -266,21 +280,20 @@ content:
             weight: 0
             settings:
               position: RIGHT_CENTER
+              behavior: default
             enabled: false
           control_streetview:
             weight: 0
             settings:
               position: RIGHT_CENTER
-            enabled: false
-          control_tile_layers:
-            weight: 0
-            settings:
-              position: TOP_LEFT
+              behavior: default
             enabled: false
           control_zoom:
             weight: 0
             settings:
-              position: RIGHT_CENTER
+              position: RIGHT_BOTTOM
+              behavior: default
+              style: LARGE
             enabled: true
           map_restriction:
             weight: 0
@@ -296,6 +309,106 @@ content:
             settings:
               style: '[]'
             enabled: false
+          marker_clusterer:
+            weight: 0
+            settings:
+              image_path: ''
+              styles: ''
+              max_zoom: 15
+              minimum_cluster_size: 2
+              zoom_on_click: true
+              average_center: false
+              grid_size: 60
+            enabled: false
+          marker_icon:
+            weight: 0
+            settings:
+              marker_icon_path: ''
+              anchor:
+                x: 0
+                'y': 0
+              origin:
+                x: 0
+                'y': 0
+              label_origin:
+                x: 0
+                'y': 0
+              size:
+                width: null
+                height: null
+              scaled_size:
+                width: null
+                height: null
+            enabled: false
+          marker_infobubble:
+            weight: 0
+            settings:
+              close_other: 1
+              close_button: 0
+              close_button_src: ''
+              shadow_style: 0
+              padding: 10
+              border_radius: 8
+              border_width: 2
+              border_color: '#039be5'
+              background_color: '#fff'
+              min_width: null
+              max_width: 550
+              min_height: null
+              max_height: null
+              arrow_style: 2
+              arrow_position: 30
+              arrow_size: 10
+            enabled: false
+          marker_infowindow:
+            weight: 0
+            settings:
+              info_window_solitary: true
+              disable_auto_pan: true
+              info_auto_display: false
+              max_width: null
+            enabled: true
+          marker_label:
+            weight: 0
+            settings:
+              color: ''
+              font_family: ''
+              font_size: ''
+              font_weight: ''
+            enabled: false
+          marker_opacity:
+            weight: 0
+            settings:
+              opacity: 1.0
+            enabled: false
+          geolocation_marker_scroll_to_id:
+            weight: 0
+            settings:
+              scroll_target_id: ''
+            enabled: false
+          marker_zoom_to_animate:
+            weight: 0
+            settings:
+              marker_zoom_anchor_id: ''
+            enabled: false
+          spiderfying:
+            weight: 0
+            settings:
+              spiderfiable_marker_path: /modules/contrib/geolocation/modules/geolocation_google_maps/images/marker-plus.svg
+              markersWontMove: true
+              markersWontHide: false
+              keepSpiderfied: true
+              ignoreMapClick: false
+              nearbyDistance: 20
+              circleSpiralSwitchover: 9
+              circleFootSeparation: 23
+              spiralFootSeparation: 26
+              spiralLengthStart: 11
+              spiralLengthFactor: 4
+              legWeight: 1.5
+              spiralIconWidth: 23
+              spiralIconHeight: 32
+            enabled: false
           google_maps_layer_traffic:
             weight: 0
             enabled: false
@@ -309,126 +422,6 @@ content:
         height: 400px
         width: 100%
         gestureHandling: auto
-        conditional_initialization: viewport
-        conditional_description: 'Clicking this button will embed a map.'
-        conditional_label: 'Show map'
-        conditional_viewport_threshold: 0.8
-        data_layers:
-          'geolocation_default_layer:default':
-            enabled: true
-            weight: -1
-            settings:
-              features:
-                marker_clusterer:
-                  enabled: false
-                  weight: 0
-                marker_icon:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    marker_icon_path: ''
-                    anchor:
-                      x: 0
-                      'y': 0
-                    origin:
-                      x: 0
-                      'y': 0
-                    label_origin:
-                      x: 0
-                      'y': 0
-                    size:
-                      width: null
-                      height: null
-                    scaled_size:
-                      width: null
-                      height: null
-                marker_infobubble:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    close_other: 1
-                    close_button: 0
-                    close_button_src: ''
-                    shadow_style: 0
-                    padding: 10
-                    border_radius: 8
-                    border_width: 2
-                    border_color: '#039be5'
-                    background_color: '#fff'
-                    min_width: null
-                    max_width: 550
-                    min_height: null
-                    max_height: null
-                    arrow_style: 2
-                    arrow_position: 30
-                    arrow_size: 10
-                marker_infowindow:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    info_window_solitary: true
-                    disable_auto_pan: true
-                    info_auto_display: false
-                    max_width: null
-                marker_label:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    color: ''
-                    font_family: ''
-                    font_size: ''
-                    font_weight: ''
-                marker_opacity:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    opacity: 1.0
-                marker_zoom_by_anchor:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    marker_zoom_anchor_id: ''
-                spiderfying:
-                  enabled: false
-                  weight: 0
-                  settings:
-                    spiderfiable_marker_path: /modules/contrib/geolocation/modules/geolocation_google_maps/images/marker-plus.svg
-                    markersWontMove: true
-                    markersWontHide: false
-                    keepSpiderfied: true
-                    ignoreMapClick: false
-                    nearbyDistance: 20
-                    circleSpiralSwitchover: 9
-                    circleFootSeparation: 23
-                    spiralFootSeparation: 26
-                    spiralLengthStart: 11
-                    spiralLengthFactor: 4
-                    legWeight: 1.5
-                    spiralIconWidth: 23
-                    spiralIconHeight: 32
-        tile_layers:
-          geolocation_tile_thunderforest:
-            settings:
-              apikey: ''
-            layers:
-              'geolocation_tile_thunderforest:cycle':
-                enabled: 0
-              'geolocation_tile_thunderforest:transport':
-                enabled: 0
-              'geolocation_tile_thunderforest:transport-dark':
-                enabled: 0
-              'geolocation_tile_thunderforest:spinal-map':
-                enabled: 0
-              'geolocation_tile_thunderforest:landscape':
-                enabled: 0
-              'geolocation_tile_thunderforest:outdoors':
-                enabled: 0
-              'geolocation_tile_thunderforest:pioneer':
-                enabled: 0
-              'geolocation_tile_thunderforest:mobile-atlas':
-                enabled: 0
-              'geolocation_tile_thunderforest:neighbourhood':
-                enabled: 0
       data_provider_settings: {  }
     third_party_settings: {  }
     weight: 6

--- a/config/sync/core.entity_view_mode.node.external_link.yml
+++ b/config/sync/core.entity_view_mode.node.external_link.yml
@@ -1,0 +1,11 @@
+uuid: 6d8fa8d3-1a52-44eb-9b64-ff2a334a40b0
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.external_link
+label: 'External link'
+description: ''
+targetEntityType: node
+cache: true

--- a/config/sync/field.field.node.contact.body.yml
+++ b/config/sync/field.field.node.contact.body.yml
@@ -12,7 +12,7 @@ field_name: body
 entity_type: node
 bundle: contact
 label: Body
-description: ''
+description: "Use this field for general information relating to the contact.  Do not use to provide the contact's address or phone numbers."
 required: false
 translatable: false
 default_value: {  }
@@ -20,4 +20,5 @@ default_value_callback: ''
 settings:
   display_summary: true
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/config/sync/field.field.node.contact.field_show_external_link.yml
+++ b/config/sync/field.field.node.contact.field_show_external_link.yml
@@ -9,8 +9,8 @@ id: node.contact.field_show_external_link
 field_name: field_show_external_link
 entity_type: node
 bundle: contact
-label: 'Show external link'
-description: "'Yes' will set the contact to link to the external website URL rather than this node. 'No' will ensure users see this contact node in search results and listings."
+label: 'Show contact as external link'
+description: "If enabled, this contact will be listed as an external link to the contact's website address."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/node.type.contact.yml
+++ b/config/sync/node.type.contact.yml
@@ -18,6 +18,8 @@ third_party_settings:
     toc_source_container: ''
     toc_element: h2
     toc_exclusions: ''
+    toc_screen_depth: '1'
+    toc_debug: 0
 name: Contact
 type: contact
 description: 'Use this content type for contact pages.'

--- a/web/modules/custom/nidirect_contacts/nidirect_contacts.module
+++ b/web/modules/custom/nidirect_contacts/nidirect_contacts.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
@@ -499,18 +500,16 @@ function nidirect_contacts_form_node_form_alter(&$form, FormStateInterface $form
 /**
  * Implements hook_entity_view_mode_alter().
  */
-function nidirect_contacts_entity_view_mode_alter(&$view_mode, \Drupal\Core\Entity\EntityInterface $entity):void {
-
-  if ($entity->getEntityTypeId() !== 'node' || $entity->bundle() !== 'contact') {
-    return;
-  }
+function nidirect_contacts_entity_view_mode_alter(&$view_mode, EntityInterface $entity):void {
 
   // Only affect full node view.
   if ($view_mode !== 'full') {
     return;
   }
 
-  if ($entity->get('field_show_external_link')->value) {
-    $view_mode = 'external_link';
+  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'contact') {
+    if ($entity->get('field_show_external_link')->value) {
+      $view_mode = 'external_link';
+    }
   }
 }

--- a/web/modules/custom/nidirect_contacts/nidirect_contacts.module
+++ b/web/modules/custom/nidirect_contacts/nidirect_contacts.module
@@ -6,8 +6,6 @@
  */
 
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Entity\EntityFormInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
@@ -501,7 +499,7 @@ function nidirect_contacts_form_node_form_alter(&$form, FormStateInterface $form
 /**
  * Implements hook_entity_view_mode_alter().
  */
-function nidirect_contacts_entity_view_mode_alter(&$view_mode, EntityInterface $entity) {
+function nidirect_contacts_entity_view_mode_alter(&$view_mode, \Drupal\Core\Entity\EntityInterface $entity):void {
 
   if ($entity->getEntityTypeId() !== 'node' || $entity->bundle() !== 'contact') {
     return;

--- a/web/modules/custom/nidirect_contacts/nidirect_contacts.module
+++ b/web/modules/custom/nidirect_contacts/nidirect_contacts.module
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
@@ -494,5 +495,24 @@ function nidirect_contacts_form_node_form_alter(&$form, FormStateInterface $form
         $selector => ['checked' => TRUE],
       ];
     }
+  }
+}
+
+/**
+ * Implements hook_entity_view_mode_alter().
+ */
+function nidirect_contacts_entity_view_mode_alter(&$view_mode, EntityInterface $entity) {
+
+  if ($entity->getEntityTypeId() !== 'node' || $entity->bundle() !== 'contact') {
+    return;
+  }
+
+  // Only affect full node view.
+  if ($view_mode !== 'full') {
+    return;
+  }
+
+  if ($entity->get('field_show_external_link')->value) {
+    $view_mode = 'external_link';
   }
 }

--- a/web/modules/custom/nidirect_contacts/nidirect_contacts.module
+++ b/web/modules/custom/nidirect_contacts/nidirect_contacts.module
@@ -452,10 +452,47 @@ function nidirect_contacts_form_node_form_alter(&$form, FormStateInterface $form
     return;
   }
 
-  // Put the checkbox directly beneath the website field.
-  $form['field_show_external_link']['#weight'] = (int) count($form['field_contact_website']['widget'][0]) + 1;
+  if (isset($form['field_show_external_link'])) {
 
-  // Nest it under the website field wrapper so they appear together.
-  $form['field_contact_website']['widget'][0]['field_show_external_link'] = $form['field_show_external_link'];
-  unset($form['field_show_external_link']);
+    $selector = ':input[name="field_show_external_link[value]"]';
+
+    $fields_to_toggle = [
+      // group_general fields...
+      'field_contact_additional_info',
+      'field_address',
+      'body',
+      'field_contact_category',
+      'field_email_address',
+      'field_location',
+      'field_related_info',
+      'field_contact_hours',
+      'field_phone',
+      'field_summary',
+    ];
+
+    foreach ($fields_to_toggle as $field_name) {
+      if (isset($form[$field_name])) {
+        $form[$field_name]['#states'] = [
+          'invisible' => [
+            $selector => ['checked' => TRUE],
+          ],
+        ];
+
+        $form[$field_name]['widget'][0]['#states'] = [
+          'invisible' => [
+            $selector => ['checked' => TRUE],
+          ],
+        ];
+      }
+    }
+
+    if (isset($form['field_contact_website']['widget'][0]['uri'])) {
+      $form['field_contact_website']['widget'][0]['uri']['#states']['required'] = [
+        $selector => ['checked' => TRUE],
+      ];
+      $form['field_contact_website']['widget'][0]['title']['#states']['invisible'] = [
+        $selector => ['checked' => TRUE],
+      ];
+    }
+  }
 }

--- a/web/modules/custom/nidirect_contacts/nidirect_contacts.module
+++ b/web/modules/custom/nidirect_contacts/nidirect_contacts.module
@@ -507,7 +507,7 @@ function nidirect_contacts_entity_view_mode_alter(&$view_mode, EntityInterface $
     return;
   }
 
-  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'contact') {
+  if ($entity instanceof NodeInterface && $entity->bundle() === 'contact') {
     if ($entity->get('field_show_external_link')->value) {
       $view_mode = 'external_link';
     }

--- a/web/themes/custom/nicsdru_nidirect_theme/templates/content/node--contact--external-link.html.twig
+++ b/web/themes/custom/nicsdru_nidirect_theme/templates/content/node--contact--external-link.html.twig
@@ -1,0 +1,88 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+<article{{ attributes.setAttribute('id', 'main-article').removeAttribute('role') }}>
+  {% if show_title %}
+  {{ drupal_block('page_title_block', wrapper=false) }}
+  {% endif %}
+  {% if  content_attributes is not empty %}
+  <div{{ content_attributes }}>
+  {% endif %}
+  {{- content -}}
+  {{ drupal_block('views_block:contact_children-contact_children', wrapper=false) }}
+  {% if  content_attributes is not empty %}
+  </div>
+  {% endif %}
+  {% if display_social_links %}
+    {{ drupal_entity('block', 'originssocialsharing', check_access=false) }}
+  {% endif %}
+</article>


### PR DESCRIPTION
- Move field_show_external_link to top of node edit form (below title).
- When checked, hide fields that are no longer relevant to the editor and make website URL mandatory
- Re-enable Google Maps Geolocation API on the location field (for some reason it had changed to geolocation_html5)
- Adjustments to order and grouping of form fields